### PR TITLE
use travis-ci for continuous integration

### DIFF
--- a/.ci.yml
+++ b/.ci.yml
@@ -1,9 +1,0 @@
-environment:
-  language: java
-  language_versions: 1.8.0_60
-  packages:
-    - apache_maven-3.1.1
-    - npm_npm-2015.02.27_20.23
-    - node-v6.1.0
-build: 
-  run: mvn -U clean deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+language: java
+jdk:
+  - oraclejdk8
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+before_install:
+  - nvm install 6.0
+  - npm install -g npm
+

--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -16,7 +16,9 @@ Build Process
 
 The project is written in [Java 8](http://openjdk.java.net/) and built using [maven](http://maven.apache.org/).
 As of time of writing, all tests are unit tests and should work entirely independant of the environment you are running.
-Make sure your tests pass: ``maven test``.
+Make sure your tests pass: ``mvn test``.
+
+Note that older releases of JDK 8 have a bug which will cause crashes while running this code. It is recommended that you use a recent build of JDK 8 (at the time of writing, version 1.8.91 is being used). Monsoon does not run on JDK versions below 8 due to a reliance on language features introduced in version 8.
 
 Release Process
 ----


### PR DESCRIPTION
Remove dotCI config, and add a travis config. Make some small changes to the README

Some notes on the travis config:

1) Force an update of the Oracle JDK - the default one is 1.8.31 which has some bugs which causes the JVM to segfault while running Monsoon's tests.
2) While the tests run in Travis' Java environment, node/npm is available. Ensure that node and npm are updated before running the tests for the UI (the default version is too old to install Angular 2)
3) `sudo: required` forces the tests to be run inside a VM inside of a Docker container. The VM has more memory, which is necessary to run the tests for the history module.

Future work:

Optimize the history module tests to run within 4GB of memory.

Sample passing builds:

https://travis-ci.org/dmjb/monsoon/builds/141826559