### PR TITLE
Push pipeline

### DIFF
--- a/api_server/src/main/java/com/groupon/lex/metrics/api/ApiServer.java
+++ b/api_server/src/main/java/com/groupon/lex/metrics/api/ApiServer.java
@@ -2,6 +2,7 @@ package com.groupon.lex.metrics.api;
 
 import com.groupon.lex.metrics.httpd.EndpointRegistration;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -29,12 +30,8 @@ public class ApiServer implements AutoCloseable, EndpointRegistration {
     private final ContextHandlerCollection context_ = new ContextHandlerCollection();
     private final ServletContextHandler servlet_handler;
 
-    public ApiServer() {
-        this(9998);
-    }
-
-    public ApiServer(int port) {
-        server_ = new Server(port);
+    public ApiServer(InetSocketAddress address) {
+        server_ = new Server(address);
 
         final HandlerList chain = new HandlerList();
         {

--- a/api_server/src/main/java/com/groupon/lex/metrics/api/ApiServer.java
+++ b/api_server/src/main/java/com/groupon/lex/metrics/api/ApiServer.java
@@ -25,11 +25,17 @@ import org.eclipse.jetty.util.resource.Resource;
 public class ApiServer implements AutoCloseable, EndpointRegistration {
     private static final Logger LOG = Logger.getLogger(ApiServer.class.getName());
     private final static Charset UTF8 = Charset.forName("UTF-8");
-    private final Server server_ = new Server(9998);
+    private final Server server_;
     private final ContextHandlerCollection context_ = new ContextHandlerCollection();
     private final ServletContextHandler servlet_handler;
 
     public ApiServer() {
+        this(9998);
+    }
+
+    public ApiServer(int port) {
+        server_ = new Server(port);
+
         final HandlerList chain = new HandlerList();
         {
             final Handler index_html_handler = new AbstractHandler() {

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -40,6 +40,11 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.groupon.lex</groupId>
+            <artifactId>monsoon-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore-nio</artifactId>
             <version>4.4.4</version>

--- a/impl/src/main/java/com/groupon/lex/metrics/MetricRegistryInstance.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/MetricRegistryInstance.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -57,7 +57,6 @@ import org.joda.time.Duration;
  */
 public class MetricRegistryInstance implements MetricRegistry, AutoCloseable {
     private static final Logger logger = Logger.getLogger(MetricRegistryInstance.class.getName());
-    private final String package_name_;
     private final Collection<GroupGenerator> generators_ = new ArrayList<>();
     private long failed_collections_ = 0;
     private final boolean has_config_;
@@ -65,8 +64,7 @@ public class MetricRegistryInstance implements MetricRegistry, AutoCloseable {
     private Optional<Duration> processor_duration_ = Optional.empty();
     private final EndpointRegistration api_;
 
-    protected MetricRegistryInstance(String package_name, boolean has_config, EndpointRegistration api) {
-        package_name_ = requireNonNull(package_name);
+    protected MetricRegistryInstance(boolean has_config, EndpointRegistration api) {
         api_ = requireNonNull(api);
         has_config_ = has_config;
         api_.addEndpoint("/monsoon/metrics", new ListMetrics());
@@ -148,12 +146,11 @@ public class MetricRegistryInstance implements MetricRegistry, AutoCloseable {
      * Create a plain, uninitialized metric registry.
      *
      * The metric registry is registered under its mbeanObjectName(package_name).
-     * @param package_name The name of the package that owns this registry.
      * @param has_config True if the metric registry will be configured.
      * @return An empty metric registry.
      */
-    public static synchronized MetricRegistryInstance create(String package_name, boolean has_config, EndpointRegistration api) {
-        return new MetricRegistryInstance(package_name, has_config, api);
+    public static synchronized MetricRegistryInstance create(boolean has_config, EndpointRegistration api) {
+        return new MetricRegistryInstance(has_config, api);
     }
 
     /**
@@ -168,19 +165,6 @@ public class MetricRegistryInstance implements MetricRegistry, AutoCloseable {
                         logger.log(Level.SEVERE, "failed to close group generator " + g, t);
                     }
                 });
-    }
-
-    /**
-     * Returns a support instance, that will manage registrations under the package configured for this MetricRegistry.
-     * @return A supporting class, that helps with registering metrics and groups in the JMX context.
-     */
-    public Support getSupport() {
-        return new Support(package_name_);
-    }
-
-    @Override
-    public String getPackageName() {
-        return package_name_;
     }
 
     @Override

--- a/impl/src/main/java/com/groupon/lex/metrics/MetricRegistryInstance.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/MetricRegistryInstance.java
@@ -165,6 +165,13 @@ public class MetricRegistryInstance implements MetricRegistry, AutoCloseable {
                         logger.log(Level.SEVERE, "failed to close group generator " + g, t);
                     }
                 });
+        if (api_ instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable)api_).close();
+            } catch (Exception ex) {
+                logger.log(Level.SEVERE, "unable to close API " + api_.getClass(), ex);
+            }
+        }
     }
 
     @Override

--- a/impl/src/main/java/com/groupon/lex/metrics/PipelineBuilder.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PipelineBuilder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics;
+
+import com.groupon.lex.metrics.api.ApiServer;
+import com.groupon.lex.metrics.config.Configuration;
+import com.groupon.lex.metrics.config.ConfigurationException;
+import com.groupon.lex.metrics.history.CollectHistory;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+import lombok.NonNull;
+
+public class PipelineBuilder {
+    @NonNull
+    private final Configuration cfg_;
+    private int api_port_ = 9998;
+    private CollectHistory history_;
+    private int interval_ = 60;
+
+    public PipelineBuilder(Configuration cfg) {
+        cfg_ = cfg;
+    }
+
+    public PipelineBuilder(File dir, Reader reader) throws IOException, ConfigurationException {
+        cfg_ = Configuration.readFromFile(dir, reader);
+    }
+
+    public PipelineBuilder(File file) throws IOException, ConfigurationException {
+        cfg_ = Configuration.readFromFile(file);
+    }
+
+    public PipelineBuilder withApiPort(int api_port) {
+        if (api_port <= 0 || api_port >= 65536) throw new IllegalArgumentException("port must be a valid TCP port");
+        api_port_ = api_port;
+        return this;
+    }
+
+    public PipelineBuilder withHistory(CollectHistory history) {
+        history_ = history;
+        return this;
+    }
+
+    public PipelineBuilder withCollectIntervalSeconds(int seconds) {
+        if (seconds <= 0) throw new IllegalArgumentException("not enough seconds: " + seconds);
+        interval_ = seconds;
+        return this;
+    }
+
+    public PushProcessorPipeline build(List<PushProcessor> processor) {
+        final ApiServer api = new ApiServer(api_port_);
+        final PushMetricRegistryInstance registry = cfg_.create(api);
+        if (history_ != null)
+            registry.setHistory(history_);
+        return new PushProcessorPipeline(registry, interval_, processor);
+    }
+}

--- a/impl/src/main/java/com/groupon/lex/metrics/PipelineBuilder.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PipelineBuilder.java
@@ -54,14 +54,17 @@ public class PipelineBuilder {
         public PushProcessor build(EndpointRegistration epr) throws Exception;
     }
 
+    public static final int DEFAULT_API_PORT = 9998;
+    public static final int DEFAULT_COLLECT_INTERVAL_SECONDS = 60;
+
     @NonNull
     private final Configuration cfg_;
-    private int api_port_ = 9998;
+    private int api_port_ = DEFAULT_API_PORT;
     private CollectHistory history_;
-    private int collect_interval_seconds_ = 60;
+    private int collect_interval_seconds_ = DEFAULT_COLLECT_INTERVAL_SECONDS;
 
     /** Create a new pipeline with the given configuration. */
-    public PipelineBuilder(Configuration cfg) {
+    public PipelineBuilder(@NonNull Configuration cfg) {
         cfg_ = cfg;
     }
 

--- a/impl/src/main/java/com/groupon/lex/metrics/PipelineBuilder.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PipelineBuilder.java
@@ -53,11 +53,11 @@ public class PipelineBuilder {
     }
 
     public PipelineBuilder(File dir, Reader reader) throws IOException, ConfigurationException {
-        cfg_ = Configuration.readFromFile(dir, reader);
+        cfg_ = Configuration.readFromFile(dir, reader).resolve();
     }
 
     public PipelineBuilder(File file) throws IOException, ConfigurationException {
-        cfg_ = Configuration.readFromFile(file);
+        cfg_ = Configuration.readFromFile(file).resolve();
     }
 
     public PipelineBuilder withApiPort(int api_port) {

--- a/impl/src/main/java/com/groupon/lex/metrics/PushMetricRegistryInstance.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PushMetricRegistryInstance.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -75,12 +75,12 @@ public class PushMetricRegistryInstance extends MetricRegistryInstance {
     private Optional<Duration> rule_eval_duration_ = Optional.empty();
     private Optional<CollectHistory> history_ = Optional.empty();
 
-    public PushMetricRegistryInstance(String package_name, boolean has_config, EndpointRegistration api) {
-        this(package_name, () -> DateTime.now(DateTimeZone.UTC), has_config, api);
+    public PushMetricRegistryInstance(boolean has_config, EndpointRegistration api) {
+        this(() -> DateTime.now(DateTimeZone.UTC), has_config, api);
     }
 
-    public PushMetricRegistryInstance(String package_name, Supplier<DateTime> now, boolean has_config, EndpointRegistration api) {
-        super(package_name, has_config, api);
+    public PushMetricRegistryInstance(Supplier<DateTime> now, boolean has_config, EndpointRegistration api) {
+        super(has_config, api);
         now_ = requireNonNull(now);
         decorators_.add(new MonitorMonitor(this));
     }
@@ -180,13 +180,12 @@ public class PushMetricRegistryInstance extends MetricRegistryInstance {
      * Create a plain, uninitialized metric registry.
      *
      * The metric registry is registered under its mbeanObjectName(package_name).
-     * @param package_name The name of the package that owns this registry.
      * @param now A function returning DateTime.now(DateTimeZone.UTC).  Allowing specifying it, for the benefit of unit tests.
      * @param has_config True if the metric registry instance should mark monsoon as being supplied with a configuration file.
      * @param api The endpoint registration interface.
      * @return An empty metric registry.
      */
-    public static synchronized PushMetricRegistryInstance create(String package_name, Supplier<DateTime> now, boolean has_config, EndpointRegistration api) {
-        return new PushMetricRegistryInstance(package_name, now, has_config, api);
+    public static synchronized PushMetricRegistryInstance create(Supplier<DateTime> now, boolean has_config, EndpointRegistration api) {
+        return new PushMetricRegistryInstance(now, has_config, api);
     }
 }

--- a/impl/src/main/java/com/groupon/lex/metrics/PushProcessorPipeline.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PushProcessorPipeline.java
@@ -104,12 +104,11 @@ public class PushProcessorPipeline extends AbstractProcessor<PushMetricRegistryI
         registry_.updateProcessorDuration(Duration.millis(TimeUnit.NANOSECONDS.toMillis(t_processor - t0)));
     }
 
-    public final Support getSupport() { return registry_.getSupport(); }
     public final int getIntervalSeconds() { return interval_seconds_; }
 
     private synchronized void stop_() {
         my_task_.ifPresent((sf) -> {
-                    logger.log(Level.INFO, "Stopping thread for push processor for {0}", getMetricRegistry().getPackageName());
+                    logger.log(Level.INFO, "Stopping thread for push processor");
                     sf.cancel(false);
                 });
         my_task_ = Optional.empty();
@@ -120,7 +119,7 @@ public class PushProcessorPipeline extends AbstractProcessor<PushMetricRegistryI
 
     private synchronized void start_(ScheduledExecutorService ses, boolean own_ses) {
         stop_();
-        logger.log(Level.INFO, "Starting thread for push processor for {0}", getMetricRegistry().getPackageName());
+        logger.log(Level.INFO, "Starting thread for push processor");
         my_task_ = Optional.of(ses.scheduleAtFixedRate(this, INITIAL_RUN_DELAY, getIntervalSeconds(), TimeUnit.SECONDS));
         if (own_ses) owner_executor_ = Optional.of(ses);
     }
@@ -136,7 +135,7 @@ public class PushProcessorPipeline extends AbstractProcessor<PushMetricRegistryI
 
         start_(Executors.newSingleThreadScheduledExecutor((Runnable r) -> {
                     logger.entering(getClass().getName(), "start_", r);
-                    Thread t = new Thread(r, getMetricRegistry().getPackageName());
+                    Thread t = new Thread(r, "monsoon processor");
                     t.setDaemon(daemon);
                     t.setPriority(thread_priority);
                     return t;
@@ -186,7 +185,7 @@ public class PushProcessorPipeline extends AbstractProcessor<PushMetricRegistryI
 
     @Override
     public void close() {
-        logger.log(Level.INFO, "Closing push processor for {0}", getMetricRegistry().getPackageName());
+        logger.log(Level.INFO, "Closing push processor");
         stop_();
         super.close();
 

--- a/impl/src/main/java/com/groupon/lex/metrics/PushProcessorPipeline.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PushProcessorPipeline.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -31,6 +31,14 @@
  */
 package com.groupon.lex.metrics;
 
+import com.groupon.lex.metrics.timeseries.Alert;
+import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
+import java.util.ArrayList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.unmodifiableList;
+import java.util.List;
+import java.util.Map;
+import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -38,39 +46,62 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.joda.time.Duration;
 
 /**
+ * A push pipeline.
  *
+ * The pipeline periodically performs a scrape, processes it and then emits it
+ * to all processors it holds.
  * @author ariane
  */
-public abstract class AbstractPushProcessor extends AbstractProcessor<PushMetricRegistryInstance> implements Runnable {
-    private static final Logger logger = Logger.getLogger(AbstractPushProcessor.class.getName());
+public class PushProcessorPipeline extends AbstractProcessor<PushMetricRegistryInstance> implements Runnable {
+    private static final Logger logger = Logger.getLogger(PushProcessorPipeline.class.getName());
     private static final int INITIAL_RUN_DELAY = 5;  /* seconds */
     private final int interval_seconds_;
     private Optional<ScheduledExecutorService> owner_executor_ = Optional.empty();
     private Optional<ScheduledFuture<?>> my_task_ = Optional.empty();
+    private final List<PushProcessor> processors_;
 
-    public AbstractPushProcessor(PushMetricRegistryInstance registry, int interval_seconds) {
+    public PushProcessorPipeline(PushMetricRegistryInstance registry, int interval_seconds, List<PushProcessor> processors) {
         super(registry);
         interval_seconds_ = interval_seconds;
+        processors_ = unmodifiableList(new ArrayList<>(processors));
+    }
+
+    public PushProcessorPipeline(PushMetricRegistryInstance registry, int interval_seconds, PushProcessor processor) {
+        this(registry, interval_seconds, singletonList(requireNonNull(processor)));
     }
 
     /**
-     * Run the implementation of uploading the values.
+     * Run the implementation of uploading the values and alerts.
      * @throws java.lang.Exception thrown by implementation.
      */
-    protected abstract void runImplementation() throws Exception;
+    private void run_implementation_(PushProcessor p) throws Exception {
+        final Map<GroupName, Alert> alerts = registry_.getCollectionAlerts();
+        final TimeSeriesCollection tsdata = registry_.getCollectionData();
+        p.accept(tsdata, alerts);
+    }
 
     /**
      * Run the collection cycle.
      */
     @Override
     public final void run() {
-        try {
-            runImplementation();
-        } catch (Exception ex) {
-            logger.log(Level.SEVERE, "Failed to run properly, some or all metrics may be missed this cycle", ex);
-        }
+        registry_.updateCollection();
+
+        final long t0 = System.nanoTime();
+
+        processors_.forEach(p -> {
+            try {
+                run_implementation_(p);
+            } catch (Exception ex) {
+                logger.log(Level.SEVERE, p.getClass().getName() + " failed to run properly, some or all metrics may be missed this cycle", ex);
+            }
+        });
+
+        final long t_processor = System.nanoTime();
+        registry_.updateProcessorDuration(Duration.millis(TimeUnit.NANOSECONDS.toMillis(t_processor - t0)));
     }
 
     public final Support getSupport() { return registry_.getSupport(); }
@@ -158,5 +189,13 @@ public abstract class AbstractPushProcessor extends AbstractProcessor<PushMetric
         logger.log(Level.INFO, "Closing push processor for {0}", getMetricRegistry().getPackageName());
         stop_();
         super.close();
+
+        processors_.forEach(p -> {
+            try {
+                p.close();
+            } catch (Exception ex) {
+                logger.log(Level.SEVERE, "failed to close " + p.getClass().getName(), ex);
+            }
+        });
     }
 }

--- a/impl/src/main/java/com/groupon/lex/metrics/config/Configuration.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/config/Configuration.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -86,16 +86,15 @@ public class Configuration {
 
     /**
      * Creates a new MetricRegistryInstance and exposes it using JMX.
-     * @param package_name the implementation package, under which the MetricRegistryInstance will be registered.
-     * @param conn JMX client connection.
      * @param now A function returning DateTime.now(DateTimeZone.UTC).  Allowing specifying it, for the benefit of unit tests.
+     * @param api The api with which to register configuration-specific endpoints.
      * @return A metric registry instance, initialized based on this configuration.
      * @throws RuntimeException if anything goes wrong during registration, for example the name is already in use.
      */
-    public synchronized PushMetricRegistryInstance create(String package_name, Supplier<DateTime> now, EndpointRegistration api) {
+    public synchronized PushMetricRegistryInstance create(Supplier<DateTime> now, EndpointRegistration api) {
         if (needsResolve()) throw new IllegalStateException("Configuration.create invoked on unresolved configuration");
 
-        PushMetricRegistryInstance spawn = PushMetricRegistryInstance.create(package_name, now, has_config_, api);
+        PushMetricRegistryInstance spawn = PushMetricRegistryInstance.create(now, has_config_, api);
         Logger.getLogger(MetricRegistryInstance.class.getName()).log(Level.INFO, "Using configuration:\n{0}", this);
         try {
             getMonitors().forEach((MonitorStatement mon) -> {
@@ -117,13 +116,12 @@ public class Configuration {
 
     /**
      * Creates a new MetricRegistryInstance and exposes it using JMX.
-     * @param package_name the implementation package, under which the MetricRegistryInstance will be registered.
-     * @param conn JMX client connection.
+     * @param api The api with which to register configuration-specific endpoints.
      * @return A metric registry instance, initialized based on this configuration.
      * @throws RuntimeException if anything goes wrong during registration, for example the name is already in use.
      */
-    public PushMetricRegistryInstance create(String package_name, EndpointRegistration api) {
-        return create(package_name, () -> DateTime.now(DateTimeZone.UTC), api);
+    public PushMetricRegistryInstance create(EndpointRegistration api) {
+        return create(() -> DateTime.now(DateTimeZone.UTC), api);
     }
 
     private final List<ImportStatement> imports_;

--- a/impl/src/main/java/com/groupon/lex/metrics/config/Configuration.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/config/Configuration.java
@@ -85,7 +85,7 @@ public class Configuration {
     private boolean has_config_ = true;
 
     /**
-     * Creates a new MetricRegistryInstance and exposes it using JMX.
+     * Creates a new MetricRegistryInstance.
      * @param now A function returning DateTime.now(DateTimeZone.UTC).  Allowing specifying it, for the benefit of unit tests.
      * @param api The api with which to register configuration-specific endpoints.
      * @return A metric registry instance, initialized based on this configuration.

--- a/impl/src/test/java/com/groupon/lex/metrics/MetricRegistryInstanceTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/MetricRegistryInstanceTest.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -69,17 +69,15 @@ public class MetricRegistryInstanceTest {
 
     @Test
     public void constructor() {
-        try (MetricRegistryInstance mr = MetricRegistryInstance.create("xyzzy.one", true, (pattern, servlet) -> {})) {
+        try (MetricRegistryInstance mr = MetricRegistryInstance.create(true, (pattern, servlet) -> {})) {
             assertTrue(mr.hasConfig());
-            assertEquals("xyzzy.one", mr.getPackageName());
 
             assertEquals(Optional.empty(), mr.getRuleEvalDuration());
             assertEquals(Optional.empty(), mr.getProcessorDuration());
         }
 
-        try (MetricRegistryInstance mr = MetricRegistryInstance.create("xyzzy.two", false, (pattern, servlet) -> {})) {
+        try (MetricRegistryInstance mr = MetricRegistryInstance.create(false, (pattern, servlet) -> {})) {
             assertFalse(mr.hasConfig());
-            assertEquals("xyzzy.two", mr.getPackageName());
 
             assertEquals(Optional.empty(), mr.getRuleEvalDuration());
             assertEquals(Optional.empty(), mr.getProcessorDuration());
@@ -88,7 +86,7 @@ public class MetricRegistryInstanceTest {
 
     @Test
     public void processor_duration_is_remembered() {
-        try (MetricRegistryInstance mr = MetricRegistryInstance.create("xyzzy.three", false, (pattern, servlet) -> {})) {
+        try (MetricRegistryInstance mr = MetricRegistryInstance.create(false, (pattern, servlet) -> {})) {
             mr.updateProcessorDuration(Duration.standardSeconds(17));
             assertEquals(Optional.of(Duration.standardSeconds(17)), mr.getProcessorDuration());
         }
@@ -99,7 +97,7 @@ public class MetricRegistryInstanceTest {
         when(generator.getGroups()).thenReturn(GroupGenerator.successResult(singleton(new SimpleMetricGroup(new GroupName("test"), Stream.of(new SimpleMetric(new MetricName("x"), 17))))));
         final DateTime now = DateTime.now(DateTimeZone.UTC);
 
-        try (MetricRegistryInstance mr = MetricRegistryInstance.create("xyzzy.four", false, (pattern, servlet) -> {})) {
+        try (MetricRegistryInstance mr = MetricRegistryInstance.create(false, (pattern, servlet) -> {})) {
             mr.add(generator);
             List<TimeSeriesValue> sgroups = mr.streamGroups(now).collect(Collectors.toList());
 
@@ -115,7 +113,7 @@ public class MetricRegistryInstanceTest {
     public void stream_groups() throws Exception {
         when(generator.getGroups()).thenReturn(GroupGenerator.successResult(singleton(new SimpleMetricGroup(new GroupName("test"), Stream.of(new SimpleMetric(new MetricName("x"), 17))))));
 
-        try (MetricRegistryInstance mr = MetricRegistryInstance.create("xyzzy.five", false, (pattern, servlet) -> {})) {
+        try (MetricRegistryInstance mr = MetricRegistryInstance.create(false, (pattern, servlet) -> {})) {
             mr.add(generator);
             mr.streamGroups().collect(Collectors.toList());
         }
@@ -128,17 +126,10 @@ public class MetricRegistryInstanceTest {
     public void group_names_resolution() throws Exception {
         when(generator.getGroups()).thenReturn(GroupGenerator.successResult(singleton(new SimpleMetricGroup(new GroupName("test"), Stream.of(new SimpleMetric(new MetricName("x"), 17))))));
 
-        try (MetricRegistryInstance mr = MetricRegistryInstance.create("xyzzy.six", false, (pattern, servlet) -> {})) {
+        try (MetricRegistryInstance mr = MetricRegistryInstance.create(false, (pattern, servlet) -> {})) {
             mr.add(generator);
             assertThat(mr.getGroupNames(),
                     arrayContaining(new GroupName("test")));
-        }
-    }
-
-    @Test
-    public void support() throws Exception {
-        try (MetricRegistryInstance mr = MetricRegistryInstance.create("xyzzy.seven", false, (pattern, servlet) -> {})) {
-            assertEquals("xyzzy.seven", mr.getSupport().getPackageName());
         }
     }
 
@@ -147,7 +138,7 @@ public class MetricRegistryInstanceTest {
         Mockito.doThrow(IOException.class).when(generator).close();
         Mockito.doThrow(IOException.class).when(extra_generator).close();
 
-        try (MetricRegistryInstance mr = MetricRegistryInstance.create("xyzzy.eight", false, (pattern, servlet) -> {})) {
+        try (MetricRegistryInstance mr = MetricRegistryInstance.create(false, (pattern, servlet) -> {})) {
             mr.add(generator);
             mr.add(extra_generator);
         }

--- a/impl/src/test/java/com/groupon/lex/metrics/PushProcessorPipelineTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/PushProcessorPipelineTest.java
@@ -34,12 +34,10 @@ package com.groupon.lex.metrics;
 import java.util.concurrent.CompletableFuture;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import static org.mockito.Mockito.when;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
@@ -54,12 +52,6 @@ public class PushProcessorPipelineTest {
     private PushMetricRegistryInstance registry;
     @Mock
     private PushProcessor processor;
-
-    @Before
-    public void setup() {
-        when(registry.getPackageName()).thenReturn("abracadabra");
-        when(registry.getSupport()).thenReturn(new Support("abracadabra"));
-    }
 
     @Test
     public void constructor() {
@@ -86,13 +78,6 @@ public class PushProcessorPipelineTest {
         }
 
         Mockito.verify(processor, Mockito.times(1)).accept(Mockito.any(), Mockito.any());
-    }
-
-    @Test
-    public void get_support() {
-        try (PushProcessorPipeline impl = new PushProcessorPipeline(registry, 10, processor)) {
-            assertEquals("abracadabra", impl.getSupport().getPackageName());
-        }
     }
 
     @Test(timeout = 25000)

--- a/impl/src/test/java/com/groupon/lex/metrics/config/ConfigurationTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/config/ConfigurationTest.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -165,7 +165,7 @@ public class ConfigurationTest {
         Configuration cfg = Configuration.readFromFile(File.listRoots()[0], new StringReader("import all\n  from \"file.name\";"));
 
         assertTrue(cfg.needsResolve());
-        cfg.create("foobar", (pattern, handler) -> {});
+        cfg.create((pattern, handler) -> {});
     }
 
     @Test
@@ -192,7 +192,7 @@ public class ConfigurationTest {
                         + "collect url \"http://localhost/\" as 'test';"));
         assertTrue(cfg.needsResolve());
         // Create must not fail.
-        try (PushMetricRegistryInstance instance = cfg.resolve().create("foobar", (pattern, handler) -> {})) {
+        try (PushMetricRegistryInstance instance = cfg.resolve().create((pattern, handler) -> {})) {
             /* SKIP */
         }
     }
@@ -227,7 +227,7 @@ public class ConfigurationTest {
                         + "collect url \"http://localhost/\" as 'test';"));
         assertTrue(cfg.needsResolve());
         // Create must not fail.
-        try (PushMetricRegistryInstance instance = cfg.resolve().create("foobar", (pattern, handler) -> {})) {
+        try (PushMetricRegistryInstance instance = cfg.resolve().create((pattern, handler) -> {})) {
             /* SKIP */
         }
     }

--- a/impl/src/test/java/com/groupon/lex/metrics/config/parser/AbstractAlertTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/config/parser/AbstractAlertTest.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -150,7 +150,7 @@ public abstract class AbstractAlertTest {
 
         try {
             final PushMetricRegistryInstance registry = Configuration.readFromFile(null, new StringReader(configuration))
-                    .create(getClass().getName(), datetime_supplier, (pattern, handler) -> {});
+                    .create(datetime_supplier, (pattern, handler) -> {});
             registry.add(new ReplayCollector(input));
             return new AlertValidator(registry);
         } catch (ConfigurationException ex) {

--- a/impl/src/test/java/com/groupon/lex/metrics/config/parser/AbstractExpressionTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/config/parser/AbstractExpressionTest.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -127,7 +127,7 @@ public abstract class AbstractExpressionTest {
 
     protected void validateExpression(String expr, DataPointStream... input) throws Exception {
         try (final PushMetricRegistryInstance registry = configurationForExpr(expr, Arrays.stream(input).map(DataPointStream::getIdentifier))
-                .create(getClass().getName(), (pattern, handler) -> {})) {
+                .create((pattern, handler) -> {})) {
             ReplayCollector replay_collector = new ReplayCollector(input);
             registry.add(replay_collector);
 

--- a/intf/src/main/java/com/groupon/lex/metrics/MetricRegistry.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/MetricRegistry.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -49,12 +49,6 @@ public interface MetricRegistry {
      * @return All groups currently known by the MetricRegistry.
      */
     public GroupName[] getGroupNames();
-
-    /**
-     * Returns the package name of the registry.
-     * @return the name of the package, that uses this registry.
-     */
-    public String getPackageName();
 
     /**
      * Tests if the metric registry has a configuration.

--- a/intf/src/main/java/com/groupon/lex/metrics/PushProcessor.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/PushProcessor.java
@@ -4,6 +4,8 @@ import com.groupon.lex.metrics.timeseries.Alert;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
 import java.util.Map;
 
-public interface PushProcessor {
-    public void accept(TimeSeriesCollection tsdata, Map<GroupName, Alert> alerts);
+public interface PushProcessor extends AutoCloseable {
+    public void accept(TimeSeriesCollection tsdata, Map<GroupName, Alert> alerts) throws Exception;
+    @Override
+    public default void close() throws Exception {}
 }

--- a/intf/src/main/java/com/groupon/lex/metrics/Support.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/Support.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -44,6 +44,7 @@ import javax.management.ObjectName;
  *
  * @author ariane
  */
+@Deprecated
 public class Support {
     private final String package_name_;
 

--- a/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusServer.java
+++ b/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusServer.java
@@ -35,6 +35,7 @@ import com.groupon.lex.metrics.MetricRegistryInstance;
 import com.groupon.lex.metrics.api.ApiServer;
 import com.groupon.lex.metrics.config.Configuration;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -84,7 +85,7 @@ public class PrometheusServer {
     }
 
     public static void main(String[] args) throws Exception {
-        final ApiServer api = new ApiServer();
+        final ApiServer api = new ApiServer(new InetSocketAddress(9998));
 
         PrometheusConfig cfg = createPrometheusConfig(args);
         Configuration _cfg = cfg.getConfiguration();

--- a/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusServer.java
+++ b/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusServer.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -88,7 +88,7 @@ public class PrometheusServer {
 
         PrometheusConfig cfg = createPrometheusConfig(args);
         Configuration _cfg = cfg.getConfiguration();
-        registry_ = _cfg.create(_PACKAGE_NAME, api);
+        registry_ = _cfg.create(api);
 
         api.start();
         Runtime.getRuntime().addShutdownHook(new Thread(api::close));


### PR DESCRIPTION
Create a pipeline type that encapsulates everything needed to run a push processor.  An added advantage is that we can now run with multiple processors.

While here, remove the String ``package_name`` from all constructors: it was used in the olden days to register JMX beans, but that isn't done anymore (in fact, accessing metrics via the JMX beans breaks push-based collectors, like *collectd*, which cleans out the set of metrics during a scrape).

This also implements a pipeline builder, to make it easy to create them and correctly start the pipeline.

Counterparts for pull-based collectors are not yet implemented.