### PR TITLE
remove unnecessary catches of Throwable

### DIFF
--- a/impl/src/main/java/com/groupon/lex/metrics/MetricRegistryInstance.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/MetricRegistryInstance.java
@@ -164,8 +164,8 @@ public class MetricRegistryInstance implements MetricRegistry, AutoCloseable {
         generators_.forEach((g) -> {
                     try {
                         g.close();
-                    } catch (Throwable t) {
-                        logger.log(Level.SEVERE, "failed to close group generator " + g, t);
+                    } catch (Exception e) {
+                        logger.log(Level.SEVERE, "failed to close group generator " + g, e);
                     }
                 });
     }

--- a/impl/src/test/java/com/groupon/lex/metrics/JmxClient_remoteTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/JmxClient_remoteTest.java
@@ -203,9 +203,9 @@ public class JmxClient_remoteTest {
         try (JmxClient jmx_client = new JmxClient(jmx_server.url)) {
             try {
                 jmx_client.getConnection();  // Ensure connection exists.
-            } catch (Throwable t) {
+            } catch (Exception e) {
                 /* Ensure we catch any exception from getConnection, just in case. */
-                throw new AssertionError("getConnection() may not throw at this point", t);
+                throw new AssertionError("getConnection() may not throw at this point", e);
             }
 
             jmx_server.stop();  // Server going down...
@@ -277,9 +277,9 @@ public class JmxClient_remoteTest {
         try (JmxClient jmx_client = new JmxClient(jmx_server.url)) {
             try {
                 jmx_client.getConnection();  // Ensure connection exists.
-            } catch (Throwable t) {
+            } catch (Exception e) {
                 /* Ensure we catch any exception from getConnection, just in case. */
-                throw new AssertionError("getConnection() may not throw at this point", t);
+                throw new AssertionError("getConnection() may not throw at this point", e);
             }
 
             jmx_server.stop();  // Server going down...

--- a/intf/src/main/java/com/groupon/lex/metrics/httpd/AlreadyStartedException.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/httpd/AlreadyStartedException.java
@@ -45,11 +45,11 @@ public class AlreadyStartedException extends Exception {
         super(msg);
     }
 
-    public AlreadyStartedException(Throwable t) {
-        super(t);
+    public AlreadyStartedException(Exception e) {
+        super(e);
     }
 
-    public AlreadyStartedException(String msg, Throwable t) {
-        super(msg, t);
+    public AlreadyStartedException(String msg, Exception e) {
+        super(msg, e);
     }
 }


### PR DESCRIPTION
Catching `Throwable` is A Bad Thing™ as it can potentially catch non recoverable JVM errors. There is one place in the code where it is necessary to accept a `Throwable` argument, other than that - replace all occurrences of `Throwable` with `Exception`.

Catching the blanket `Exception` isn't a great idea within of itself, but this is a start :)