### PR TITLE
Make pipeline and push processor interface more useful.

### DIFF
--- a/impl/src/main/java/com/groupon/lex/metrics/MetricRegistryInstance.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/MetricRegistryInstance.java
@@ -31,7 +31,6 @@
  */
 package com.groupon.lex.metrics;
 
-import com.groupon.lex.metrics.api.endpoints.ListMetrics;
 import com.groupon.lex.metrics.httpd.EndpointRegistration;
 import com.groupon.lex.metrics.timeseries.MutableTimeSeriesValue;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
@@ -67,7 +66,6 @@ public class MetricRegistryInstance implements MetricRegistry, AutoCloseable {
     protected MetricRegistryInstance(boolean has_config, EndpointRegistration api) {
         api_ = requireNonNull(api);
         has_config_ = has_config;
-        api_.addEndpoint("/monsoon/metrics", new ListMetrics());
     }
 
     @Override

--- a/impl/src/main/java/com/groupon/lex/metrics/PipelineBuilder.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PipelineBuilder.java
@@ -127,12 +127,10 @@ public class PipelineBuilder {
         final List<PushProcessor> processors = new ArrayList<>(processor_suppliers.size());
         try {
             final EndpointRegistration epr;
-            if (epr_ == null) {
-                api = new ApiServer(api_sockaddr_);
-                epr = api;
-            } else {
+            if (epr_ == null)
+                epr = api = new ApiServer(api_sockaddr_);
+            else
                 epr = epr_;
-            }
 
             registry = cfg_.create(epr);
             for (PushProcessorSupplier pps : processor_suppliers)

--- a/impl/src/main/java/com/groupon/lex/metrics/PushMetricRegistryInstance.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PushMetricRegistryInstance.java
@@ -74,6 +74,7 @@ public class PushMetricRegistryInstance extends MetricRegistryInstance {
     private Supplier<DateTime> now_;
     private Optional<Duration> rule_eval_duration_ = Optional.empty();
     private Optional<CollectHistory> history_ = Optional.empty();
+    private final ListMetrics list_metrics_;
 
     public PushMetricRegistryInstance(boolean has_config, EndpointRegistration api) {
         this(() -> DateTime.now(DateTimeZone.UTC), has_config, api);
@@ -83,6 +84,8 @@ public class PushMetricRegistryInstance extends MetricRegistryInstance {
         super(has_config, api);
         now_ = requireNonNull(now);
         decorators_.add(new MonitorMonitor(this));
+        list_metrics_ = new ListMetrics();
+        getApi().addEndpoint("/monsoon/metrics", list_metrics_);
     }
 
     /** Set the history module that the push processor is to use. */
@@ -126,7 +129,7 @@ public class PushMetricRegistryInstance extends MetricRegistryInstance {
     private synchronized void commitCollection(Map<GroupName, Alert> alerts) {
         alerts_ = unmodifiableMap(alerts);
         getHistory().ifPresent(history -> history.add(getCollectionData()));
-        ListMetrics.update(data_.getCurrentCollection());
+        list_metrics_.update(data_.getCurrentCollection());
     }
 
     /**

--- a/impl/src/main/java/com/groupon/lex/metrics/PushProcessorPipeline.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PushProcessorPipeline.java
@@ -36,6 +36,7 @@ import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
 import java.util.ArrayList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
 import java.util.List;
 import java.util.Map;
 import static java.util.Objects.requireNonNull;
@@ -80,7 +81,7 @@ public class PushProcessorPipeline extends AbstractProcessor<PushMetricRegistryI
     private void run_implementation_(PushProcessor p) throws Exception {
         final Map<GroupName, Alert> alerts = registry_.getCollectionAlerts();
         final TimeSeriesCollection tsdata = registry_.getCollectionData();
-        p.accept(tsdata, alerts);
+        p.accept(tsdata, unmodifiableMap(alerts), registry_.getFailedCollections());
     }
 
     /**

--- a/impl/src/main/java/com/groupon/lex/metrics/api/endpoints/ListMetrics.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/api/endpoints/ListMetrics.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -57,7 +57,7 @@ public class ListMetrics extends HttpServlet {
     private static final Logger LOG = Logger.getLogger(ListMetrics.class.getName());
     private final static Charset UTF8 = Charset.forName("UTF-8");
     private final static String INDENT = "    ";
-    private final static AtomicReference<List<TimeSeriesValue>> ts_data_ = new AtomicReference<>(EMPTY_LIST);
+    private final AtomicReference<List<TimeSeriesValue>> ts_data_ = new AtomicReference<>(EMPTY_LIST);
 
     private static void render_(StringBuilder out, String indent, List<TimeSeriesValue> ts_data) {
         ts_data.stream()
@@ -104,11 +104,11 @@ public class ListMetrics extends HttpServlet {
         return buf;
     }
 
-    private static StringBuilder render_() {
+    private StringBuilder render_() {
         return render_(ts_data_.get());
     }
 
-    public static void update(TimeSeriesCollection ts_data) {
+    public void update(TimeSeriesCollection ts_data) {
         ts_data_.set(ts_data.getTSValues().stream().collect(Collectors.toList()));
     }
 

--- a/impl/src/test/java/com/groupon/lex/metrics/PushProcessorPipelineTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/PushProcessorPipelineTest.java
@@ -70,14 +70,14 @@ public class PushProcessorPipelineTest {
                     run_implementation_called.complete(null);
                     return null;
                 })
-                .when(processor).accept(Mockito.any(), Mockito.any());
+                .when(processor).accept(Mockito.any(), Mockito.any(), Mockito.anyLong());
 
         try (PushProcessorPipeline impl = new PushProcessorPipeline(registry, 10, processor)) {
             impl.start();
             run_implementation_called.get();
         }
 
-        Mockito.verify(processor, Mockito.times(1)).accept(Mockito.any(), Mockito.any());
+        Mockito.verify(processor, Mockito.times(1)).accept(Mockito.any(), Mockito.any(), Mockito.anyLong());
     }
 
     @Test(timeout = 25000)
@@ -90,13 +90,13 @@ public class PushProcessorPipelineTest {
                     run_implementation_called.complete(null);
                     return null;
                 })
-                .when(processor).accept(Mockito.any(), Mockito.any());
+                .when(processor).accept(Mockito.any(), Mockito.any(), Mockito.anyLong());
 
         try (PushProcessorPipeline impl = new PushProcessorPipeline(registry, 10, processor)) {
             impl.start();
             run_implementation_called.get();
         }
 
-        Mockito.verify(processor, Mockito.times(2)).accept(Mockito.any(), Mockito.any());
+        Mockito.verify(processor, Mockito.times(2)).accept(Mockito.any(), Mockito.any(), Mockito.anyLong());
     }
 }

--- a/intf/src/main/java/com/groupon/lex/metrics/PushProcessor.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/PushProcessor.java
@@ -5,7 +5,7 @@ import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
 import java.util.Map;
 
 public interface PushProcessor extends AutoCloseable {
-    public void accept(TimeSeriesCollection tsdata, Map<GroupName, Alert> alerts) throws Exception;
+    public void accept(TimeSeriesCollection tsdata, Map<GroupName, Alert> alerts, long failed_collections) throws Exception;
     @Override
     public default void close() throws Exception {}
 }


### PR DESCRIPTION
- Add explicit override for API.
- Create PipelineBuilder.build function that only takes a single supplier.
- Propagate failed collections to Push Processors, so they can decide how
  trustworthy the data is.

This fixes some limitations I found while using the pipeline logic.