### PR TITLE
Pull pipeline

### DIFF
--- a/impl/src/main/java/com/groupon/lex/metrics/PipelineBuilder.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PipelineBuilder.java
@@ -132,7 +132,7 @@ public class PipelineBuilder {
             else
                 epr = epr_;
 
-            registry = cfg_.create(epr);
+            registry = cfg_.create(PushMetricRegistryInstance::new, epr);
             for (PushProcessorSupplier pps : processor_suppliers)
                 processors.add(pps.build(api));
 
@@ -161,5 +161,36 @@ public class PipelineBuilder {
      */
     public PushProcessorPipeline build(PushProcessorSupplier processor_supplier) throws Exception {
         return build(singletonList(processor_supplier));
+    }
+
+    /*
+     * Creates a pull processor.
+     *
+     * The API server is started by this method.
+     * The returned pull processor is thread-safe.
+     *
+     * Note that the history will not be used.
+     * @return A PullMetricRegistryInstance that performs a scrape and evaluates rules.
+     * @throws Exception indicating construction failed.
+     */
+    public PullMetricRegistryInstance build() throws Exception {
+        ApiServer api = null;
+        PullMetricRegistryInstance registry = null;
+        try {
+            final EndpointRegistration epr;
+            if (epr_ == null)
+                epr = api = new ApiServer(api_sockaddr_);
+            else
+                epr = epr_;
+
+            registry = cfg_.create(PullMetricRegistryInstance::new, api);
+
+            api.start();
+            return registry;
+        } catch (Exception ex) {
+            if (api != null) api.close();
+            if (registry != null) registry.close();
+            throw ex;
+        }
     }
 }

--- a/impl/src/main/java/com/groupon/lex/metrics/PipelineBuilder.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PipelineBuilder.java
@@ -173,7 +173,7 @@ public class PipelineBuilder {
      * @return A PullMetricRegistryInstance that performs a scrape and evaluates rules.
      * @throws Exception indicating construction failed.
      */
-    public PullMetricRegistryInstance build() throws Exception {
+    public PullProcessorPipeline build() throws Exception {
         ApiServer api = null;
         PullMetricRegistryInstance registry = null;
         try {
@@ -186,7 +186,7 @@ public class PipelineBuilder {
             registry = cfg_.create(PullMetricRegistryInstance::new, api);
 
             api.start();
-            return registry;
+            return new PullProcessorPipeline(registry);
         } catch (Exception ex) {
             if (api != null) api.close();
             if (registry != null) registry.close();

--- a/impl/src/main/java/com/groupon/lex/metrics/PullMetricRegistryInstance.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PullMetricRegistryInstance.java
@@ -29,38 +29,42 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.groupon.lex.metrics.timeseries;
+package com.groupon.lex.metrics;
 
+import com.groupon.lex.metrics.httpd.EndpointRegistration;
+import com.groupon.lex.metrics.timeseries.Alert;
+import com.groupon.lex.metrics.timeseries.TimeSeriesCollectionPair;
+import com.groupon.lex.metrics.timeseries.TimeSeriesCollectionPairInstance;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.joda.time.DateTime;
 
-/**
- *
- * @author ariane
- */
-public class TimeSeriesCollectionPairInstance extends AbstractTSCPair {
-    private final MutableTimeSeriesCollection current_;
-
-    public TimeSeriesCollectionPairInstance() {
-        current_ = new MutableTimeSeriesCollection();
+public class PullMetricRegistryInstance extends MetricRegistryInstance {
+    public PullMetricRegistryInstance(boolean has_config, EndpointRegistration api) {
+        super(has_config, api);
     }
 
-    public TimeSeriesCollectionPairInstance(DateTime now) {
-        current_ = new MutableTimeSeriesCollection(now);
+    public PullMetricRegistryInstance(Supplier<DateTime> now, boolean has_config, EndpointRegistration api) {
+        super(now, has_config, api);
     }
 
     @Override
-    public TimeSeriesCollection getCurrentCollection() {
-        return current_;
-    }
+    protected CollectionContext beginCollection(DateTime now) {
+        return new CollectionContext() {
+            private final TimeSeriesCollectionPairInstance tsdata = new TimeSeriesCollectionPairInstance(now);
 
-    public TimeSeriesCollectionPairInstance startNewCycle(DateTime timestamp, ExpressionLookBack lookback) {
-        update(current_, lookback);
-        current_.clear(timestamp);
-        return this;
-    }
+            @Override
+            public Consumer<Alert> alertManager() {
+                return (Alert alert) -> {};
+            }
 
-    @Override
-    public String toString() {
-        return "TimeSeriesCollectionPairInstance{current_=" + current_ + ", " + super.toString() + '}';
+            @Override
+            public TimeSeriesCollectionPair tsdata() {
+                return tsdata;
+            }
+
+            @Override
+            public void commit() {}
+        };
     }
 }

--- a/impl/src/main/java/com/groupon/lex/metrics/PullProcessorPipeline.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PullProcessorPipeline.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics;
+
+import com.groupon.lex.metrics.timeseries.TimeSeriesValue;
+import java.util.Collection;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * A pull processor pipeline.
+ *
+ * A pull processor performs a scrape and evaluates rules, returning the evaluated set of metrics.
+ *
+ * Note that pull processors do not keep historical data and ignore alerts.
+ */
+public class PullProcessorPipeline extends AbstractProcessor<PullMetricRegistryInstance> implements Supplier<Collection<TimeSeriesValue>> {
+    public PullProcessorPipeline(PullMetricRegistryInstance registry) {
+        super(registry);
+    }
+
+    @Override
+    public Collection<TimeSeriesValue> get() {
+        return getMetricRegistry().updateCollection().getTSValues().stream().collect(Collectors.toList());
+    }
+}

--- a/impl/src/test/java/com/groupon/lex/metrics/MetricRegistryInstanceTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/MetricRegistryInstanceTest.java
@@ -52,7 +52,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -76,21 +75,18 @@ public class MetricRegistryInstanceTest {
     @Mock
     private MetricRegistryInstance.CollectionContext cctx;
 
-    @Before
-    public void setup() {
-        when(cctx.alertManager()).thenReturn((Alert alert) -> {});
-        when(cctx.tsdata()).thenAnswer(new Answer<TimeSeriesCollectionPair>() {
-            @Override
-            public TimeSeriesCollectionPair answer(InvocationOnMock invocation) throws Throwable {
-                return new TimeSeriesCollectionPairInstance(invocation.getArgumentAt(0, DateTime.class));
-            }
-        });
-    }
-
     private MetricRegistryInstance create(boolean has_config) {
         return new MetricRegistryInstance(has_config, (pattern, handler) -> {}) {
             @Override
             protected MetricRegistryInstance.CollectionContext beginCollection(DateTime now) {
+                when(cctx.alertManager()).thenReturn((Alert alert) -> {});
+                when(cctx.tsdata()).thenAnswer(new Answer<TimeSeriesCollectionPair>() {
+                    @Override
+                    public TimeSeriesCollectionPair answer(InvocationOnMock invocation) throws Throwable {
+                        return new TimeSeriesCollectionPairInstance(now);
+                    }
+                });
+
                 return cctx;
             }
         };
@@ -100,6 +96,14 @@ public class MetricRegistryInstanceTest {
         return new MetricRegistryInstance(() -> now, has_config, (pattern, handler) -> {}) {
             @Override
             protected MetricRegistryInstance.CollectionContext beginCollection(DateTime now) {
+                when(cctx.alertManager()).thenReturn((Alert alert) -> {});
+                when(cctx.tsdata()).thenAnswer(new Answer<TimeSeriesCollectionPair>() {
+                    @Override
+                    public TimeSeriesCollectionPair answer(InvocationOnMock invocation) throws Throwable {
+                        return new TimeSeriesCollectionPairInstance(now);
+                    }
+                });
+
                 return cctx;
             }
         };

--- a/impl/src/test/java/com/groupon/lex/metrics/MetricRegistryInstanceTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/MetricRegistryInstanceTest.java
@@ -152,6 +152,18 @@ public class MetricRegistryInstanceTest {
     }
 
     @Test
+    public void collectionContext_handling() throws Exception {
+        try (MetricRegistryInstance mr = create(false)) {
+            mr.updateCollection();
+        }
+
+        verify(cctx, times(1)).alertManager();
+        verify(cctx, times(1)).tsdata();
+        verify(cctx, times(1)).commit();
+        verifyNoMoreInteractions(cctx);
+    }
+
+    @Test
     public void stream_groups() throws Exception {
         when(generator.getGroups()).thenReturn(GroupGenerator.successResult(singleton(new SimpleMetricGroup(new GroupName("test"), Stream.of(new SimpleMetric(new MetricName("x"), 17))))));
 

--- a/impl/src/test/java/com/groupon/lex/metrics/config/ConfigurationTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/config/ConfigurationTest.java
@@ -165,7 +165,7 @@ public class ConfigurationTest {
         Configuration cfg = Configuration.readFromFile(File.listRoots()[0], new StringReader("import all\n  from \"file.name\";"));
 
         assertTrue(cfg.needsResolve());
-        cfg.create((pattern, handler) -> {});
+        cfg.create(PushMetricRegistryInstance::new, (pattern, handler) -> {});
     }
 
     @Test
@@ -192,7 +192,7 @@ public class ConfigurationTest {
                         + "collect url \"http://localhost/\" as 'test';"));
         assertTrue(cfg.needsResolve());
         // Create must not fail.
-        try (PushMetricRegistryInstance instance = cfg.resolve().create((pattern, handler) -> {})) {
+        try (PushMetricRegistryInstance instance = cfg.resolve().create(PushMetricRegistryInstance::new, (pattern, handler) -> {})) {
             /* SKIP */
         }
     }
@@ -227,7 +227,7 @@ public class ConfigurationTest {
                         + "collect url \"http://localhost/\" as 'test';"));
         assertTrue(cfg.needsResolve());
         // Create must not fail.
-        try (PushMetricRegistryInstance instance = cfg.resolve().create((pattern, handler) -> {})) {
+        try (PushMetricRegistryInstance instance = cfg.resolve().create(PushMetricRegistryInstance::new, (pattern, handler) -> {})) {
             /* SKIP */
         }
     }

--- a/impl/src/test/java/com/groupon/lex/metrics/config/parser/AbstractAlertTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/config/parser/AbstractAlertTest.java
@@ -150,7 +150,7 @@ public abstract class AbstractAlertTest {
 
         try {
             final PushMetricRegistryInstance registry = Configuration.readFromFile(null, new StringReader(configuration))
-                    .create(datetime_supplier, (pattern, handler) -> {});
+                    .create(PushMetricRegistryInstance::new, datetime_supplier, (pattern, handler) -> {});
             registry.add(new ReplayCollector(input));
             return new AlertValidator(registry);
         } catch (ConfigurationException ex) {

--- a/impl/src/test/java/com/groupon/lex/metrics/config/parser/AbstractExpressionTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/config/parser/AbstractExpressionTest.java
@@ -127,7 +127,7 @@ public abstract class AbstractExpressionTest {
 
     protected void validateExpression(String expr, DataPointStream... input) throws Exception {
         try (final PushMetricRegistryInstance registry = configurationForExpr(expr, Arrays.stream(input).map(DataPointStream::getIdentifier))
-                .create((pattern, handler) -> {})) {
+                .create(PushMetricRegistryInstance::new, (pattern, handler) -> {})) {
             ReplayCollector replay_collector = new ReplayCollector(input);
             registry.add(replay_collector);
 

--- a/prometheus/src/main/java/com/groupon/lex/prometheus/DisplayMetrics.java
+++ b/prometheus/src/main/java/com/groupon/lex/prometheus/DisplayMetrics.java
@@ -30,7 +30,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.groupon.lex.prometheus;
-import com.groupon.lex.metrics.PullMetricRegistryInstance;
+import com.groupon.lex.metrics.PullProcessorPipeline;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -47,8 +47,8 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
  * @author nolofsson
  */
 public class DisplayMetrics extends AbstractHandler {
-    private final PullMetricRegistryInstance registry_;
-    public DisplayMetrics(PullMetricRegistryInstance registry ){
+    private final PullProcessorPipeline registry_;
+    public DisplayMetrics(PullProcessorPipeline registry ){
         registry_ = registry;
     }
 

--- a/prometheus/src/main/java/com/groupon/lex/prometheus/DisplayMetrics.java
+++ b/prometheus/src/main/java/com/groupon/lex/prometheus/DisplayMetrics.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -30,7 +30,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.groupon.lex.prometheus;
-import com.groupon.lex.metrics.MetricRegistryInstance;
+import com.groupon.lex.metrics.PullMetricRegistryInstance;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -47,11 +47,11 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
  * @author nolofsson
  */
 public class DisplayMetrics extends AbstractHandler {
-    private final MetricRegistryInstance registry_;
-    public DisplayMetrics(MetricRegistryInstance registry ){
+    private final PullMetricRegistryInstance registry_;
+    public DisplayMetrics(PullMetricRegistryInstance registry ){
         registry_ = registry;
-    }   
-    
+    }
+
     /**
      *
      * @param target
@@ -64,25 +64,25 @@ public class DisplayMetrics extends AbstractHandler {
     public void handle(String target,
                        Request baseRequest,
                        HttpServletRequest request,
-                       HttpServletResponse response) 
+                       HttpServletResponse response)
         throws IOException, ServletException {
-        
+
         Stream<PrometheusMetric> metrics;
         try {
-            metrics = PrometheusMetrics.filteredMetrics(registry_);         
+            metrics = PrometheusMetrics.filteredMetrics(registry_);
         } catch (Exception ex) {
             Logger.getLogger(DisplayMetrics.class.getName()).log(Level.SEVERE, null, ex);
             response.sendError(500, ex.toString());
             return;
         }
-        
+
         response.setContentType("text/plain;charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);
         baseRequest.setHandled(true);
         try {
             for (PrometheusMetric m: metrics.collect(Collectors.toList())) {
                 response.getWriter().println(m);
-            }      
+            }
         } catch (IOException ex) {
             Logger.getLogger(PrometheusServer.class.getName()).log(Level.SEVERE, null, ex);
             response.sendError(500, ex.toString());

--- a/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusConfig.java
+++ b/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusConfig.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -31,10 +31,10 @@
  */
 package com.groupon.lex.prometheus;
 
-import com.groupon.lex.metrics.config.Configuration;
 import com.groupon.lex.metrics.config.ConfigurationException;
 import java.io.File;
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  *
@@ -47,14 +47,14 @@ public class PrometheusConfig {
     private String path = "/metrics";
 
     public void setPort(short p) { port = p; }
-    
+
     public short getPort (){ return port; };
-    
+
     public String getPath() { return path; };
-    
-    public void setPath(String p) { path = p; } 
+
+    public void setPath(String p) { path = p; }
     private File config_file_;
-    
+
 
     public synchronized String getConfigFile() { return config_file_.toString(); }
 
@@ -72,19 +72,18 @@ public class PrometheusConfig {
         if (!file.isFile()) throw new IOException("expected a proper file: " + file.toString());
         config_file_ = file.getCanonicalFile();
     }
-    public Configuration getConfiguration() throws IOException, ConfigurationException {
-        if (config_file_ == null) return Configuration.DEFAULT;
-        return Configuration.readFromFile(config_file_).resolve();
+    public Optional<File> getConfiguration() throws IOException, ConfigurationException {
+        return Optional.ofNullable(config_file_);
     }
-    
+
     @Override
-    public String toString() {           
+    public String toString() {
         return new StringBuilder()
             .append("(")
             .append("prometheus_path=").append(getPort()).append(",")
             .append("prometheus_path=").append(getPath())
             .append("config=").append(getConfigFile())
             .append(")")
-            .toString();           
+            .toString();
     }
 }

--- a/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusMetrics.java
+++ b/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusMetrics.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -33,8 +33,8 @@ package com.groupon.lex.prometheus;
 
 import com.groupon.lex.metrics.GroupName;
 import com.groupon.lex.metrics.MetricName;
-import com.groupon.lex.metrics.MetricRegistryInstance;
 import com.groupon.lex.metrics.MetricValue;
+import com.groupon.lex.metrics.PullMetricRegistryInstance;
 import com.groupon.lex.metrics.timeseries.TimeSeriesValue;
 import java.util.List;
 import java.util.Map;
@@ -59,9 +59,8 @@ public class PrometheusMetrics {
      * It will filter out None values and replace all Characters that
      * Does not confirm to Prometheus Metric Format.
      */
-    public static Stream<PrometheusMetric> filteredMetrics(MetricRegistryInstance registry) throws Exception {
-
-        Stream <PrometheusMetric> m = registry.streamGroups()
+    public static Stream<PrometheusMetric> filteredMetrics(PullMetricRegistryInstance registry) throws Exception {
+        Stream <PrometheusMetric> m = registry.updateCollection().getTSValues().stream()
                 .flatMap((TimeSeriesValue i) -> {
                     Map<MetricName, MetricValue> metrics = i.getMetrics();
                     GroupName group = i.getGroup();

--- a/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusMetrics.java
+++ b/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusMetrics.java
@@ -34,7 +34,7 @@ package com.groupon.lex.prometheus;
 import com.groupon.lex.metrics.GroupName;
 import com.groupon.lex.metrics.MetricName;
 import com.groupon.lex.metrics.MetricValue;
-import com.groupon.lex.metrics.PullMetricRegistryInstance;
+import com.groupon.lex.metrics.PullProcessorPipeline;
 import com.groupon.lex.metrics.timeseries.TimeSeriesValue;
 import java.util.List;
 import java.util.Map;
@@ -59,8 +59,8 @@ public class PrometheusMetrics {
      * It will filter out None values and replace all Characters that
      * Does not confirm to Prometheus Metric Format.
      */
-    public static Stream<PrometheusMetric> filteredMetrics(PullMetricRegistryInstance registry) throws Exception {
-        Stream <PrometheusMetric> m = registry.updateCollection().getTSValues().stream()
+    public static Stream<PrometheusMetric> filteredMetrics(PullProcessorPipeline registry) throws Exception {
+        Stream <PrometheusMetric> m = registry.get().stream()
                 .flatMap((TimeSeriesValue i) -> {
                     Map<MetricName, MetricValue> metrics = i.getMetrics();
                     GroupName group = i.getGroup();

--- a/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusServer.java
+++ b/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusServer.java
@@ -32,7 +32,7 @@
 package com.groupon.lex.prometheus;
 
 import com.groupon.lex.metrics.PipelineBuilder;
-import com.groupon.lex.metrics.PullMetricRegistryInstance;
+import com.groupon.lex.metrics.PullProcessorPipeline;
 import com.groupon.lex.metrics.api.ApiServer;
 import com.groupon.lex.metrics.config.Configuration;
 import java.io.File;
@@ -53,7 +53,7 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 public class PrometheusServer {
     private static final Logger LOG = Logger.getLogger(PrometheusServer.class.getName());
     private final static String _PACKAGE_NAME = PrometheusServer.class.getPackage().getName();
-    private static PullMetricRegistryInstance registry_;
+    private static PullProcessorPipeline registry_;
 
     private final static Map<String, BiConsumer<PrometheusConfig, String>> createPrometheusConfig_ = new HashMap<String, BiConsumer<PrometheusConfig, String>>() {{
             put("config=", (PrometheusConfig, config) -> {

--- a/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusServer.java
+++ b/prometheus/src/main/java/com/groupon/lex/prometheus/PrometheusServer.java
@@ -31,13 +31,16 @@
  */
 package com.groupon.lex.prometheus;
 
-import com.groupon.lex.metrics.MetricRegistryInstance;
+import com.groupon.lex.metrics.PipelineBuilder;
+import com.groupon.lex.metrics.PullMetricRegistryInstance;
 import com.groupon.lex.metrics.api.ApiServer;
 import com.groupon.lex.metrics.config.Configuration;
+import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -50,7 +53,7 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 public class PrometheusServer {
     private static final Logger LOG = Logger.getLogger(PrometheusServer.class.getName());
     private final static String _PACKAGE_NAME = PrometheusServer.class.getPackage().getName();
-    private static MetricRegistryInstance registry_;
+    private static PullMetricRegistryInstance registry_;
 
     private final static Map<String, BiConsumer<PrometheusConfig, String>> createPrometheusConfig_ = new HashMap<String, BiConsumer<PrometheusConfig, String>>() {{
             put("config=", (PrometheusConfig, config) -> {
@@ -88,8 +91,11 @@ public class PrometheusServer {
         final ApiServer api = new ApiServer(new InetSocketAddress(9998));
 
         PrometheusConfig cfg = createPrometheusConfig(args);
-        Configuration _cfg = cfg.getConfiguration();
-        registry_ = _cfg.create(api);
+        final Optional<File> _cfg = cfg.getConfiguration();
+        if (_cfg.isPresent())
+            registry_ = new PipelineBuilder(_cfg.get()).build();
+        else
+            registry_ = new PipelineBuilder(Configuration.DEFAULT).build();
 
         api.start();
         Runtime.getRuntime().addShutdownHook(new Thread(api::close));


### PR DESCRIPTION
Implement a pipeline (okay, a ``PullMetricRegistryInstance``) for pull processors (like the prometheus processor.

- Moved rule-evaluation logic into the base ``MetricRegistryInstance``.
- ``Configuration.create(...)`` now takes a constructor argument, that allows the correct ``MetricRegistryInstance`` to be constructed.
- ``MetricRegistryInstance`` now takes care of the actual scrape, derived classes are responsible for the correct parameters only.
- ``PushMetricRegistryInstance`` is still stateful (no change there, except for how everything fits together).
- ``PullMetricRegistryInstance`` is stateless, but still protects *collectors* to ensure they don't get hit by re-entry considerations.

> Not sure if we should expose the entire ``PullMetricRegistryInstance``, as it has a lot of methods that are of no concern when creating a pull processor.  Perhaps I should make a thin, ``AutoCloseable``wrapper that just exposes a ``get()`` method, streaming metrics?

I decided that returning a ``PullProcessorPipeline`` would be nicer:
- symmetry with the Push counterpart.
- less internal methods exposed.
- none of the scraping internals are exposed either.

Since this diff and https://github.com/groupon/monsoon/pull/7 both modify the pipeline builder, the two will create a merge collision.