### PR TITLE
All calls to getTSValues() are followed by stream.

### DIFF
--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/FileTimeSeriesCollection.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/FileTimeSeriesCollection.java
@@ -100,12 +100,6 @@ public class FileTimeSeriesCollection implements TimeSeriesCollection {
     }
 
     @Override
-    public Map<SimpleGroupPath, Collection<TimeSeriesValue>> getTSValuesAsMap() {
-        return path_map_.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().values()));
-    }
-
-    @Override
     public TimeSeriesValueSet getTSValue(SimpleGroupPath name) {
         return Optional.ofNullable(path_map_.get(name))
                 .map(Map::values)

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/FileTimeSeriesCollection.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/FileTimeSeriesCollection.java
@@ -10,6 +10,7 @@ import com.groupon.lex.metrics.timeseries.TimeSeriesValue;
 import com.groupon.lex.metrics.timeseries.TimeSeriesValueSet;
 import gnu.trove.map.hash.THashMap;
 import java.util.Collection;
+import static java.util.Collections.unmodifiableCollection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -91,10 +92,17 @@ public class FileTimeSeriesCollection implements TimeSeriesCollection {
     }
 
     @Override
-    public TimeSeriesValueSet getTSValues() {
-        return new TimeSeriesValueSet(path_map_.values().stream()
+    public Collection<TimeSeriesValue> getTSValues() {
+        return unmodifiableCollection(path_map_.values().stream()
                 .map(Map::values)
-                .flatMap(Collection::stream));
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    public Map<SimpleGroupPath, Collection<TimeSeriesValue>> getTSValuesAsMap() {
+        return path_map_.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().values()));
     }
 
     @Override

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/FileTimeSeriesCollectionTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/FileTimeSeriesCollectionTest.java
@@ -115,8 +115,8 @@ public class FileTimeSeriesCollectionTest {
 
     @Test
     public void get_tsvalues() {
-        assertThat(tsc.getTSValues().asMap(), hasEntry(equalTo(tsv.getGroup().getPath()), contains(tsv)));
-        assertThat(copy.getTSValues().asMap(), hasEntry(equalTo(tsv.getGroup().getPath()), contains(tsv)));
+        assertThat(tsc.getTSValuesAsMap(), hasEntry(equalTo(tsv.getGroup().getPath()), contains(tsv)));
+        assertThat(copy.getTSValuesAsMap(), hasEntry(equalTo(tsv.getGroup().getPath()), contains(tsv)));
     }
 
     @Test

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/FileTimeSeriesCollectionTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/FileTimeSeriesCollectionTest.java
@@ -115,8 +115,8 @@ public class FileTimeSeriesCollectionTest {
 
     @Test
     public void get_tsvalues() {
-        assertThat(tsc.getTSValuesAsMap(), hasEntry(equalTo(tsv.getGroup().getPath()), contains(tsv)));
-        assertThat(copy.getTSValuesAsMap(), hasEntry(equalTo(tsv.getGroup().getPath()), contains(tsv)));
+        assertThat(tsc.getTSValues(), contains(tsv));
+        assertThat(copy.getTSValues(), contains(tsv));
     }
 
     @Test

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/AbstractTSCPair.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/AbstractTSCPair.java
@@ -4,6 +4,7 @@ import com.groupon.lex.metrics.history.CollectHistory;
 import com.groupon.lex.metrics.lib.BufferedIterator;
 import com.groupon.lex.metrics.lib.ForwardIterator;
 import java.util.ArrayList;
+import java.util.Collection;
 import static java.util.Collections.EMPTY_LIST;
 import static java.util.Collections.unmodifiableList;
 import java.util.Comparator;
@@ -47,7 +48,7 @@ public abstract class AbstractTSCPair implements TimeSeriesCollectionPair {
                 .sorted(Comparator.comparing(TimeSeriesCollection::getTimestamp))
                 .distinct()
                 .collect(Collectors.toList())) {
-            prev.merge(tsc.getTimestamp(), tsc.getTSValues().stream());
+            prev.merge(tsc.getTimestamp(), tsc.getTSValues());
             previous_.add(0, prev.clone());
         }
         LOG.log(Level.INFO, "recovered {0} scrapes from history", previous_.size());
@@ -111,7 +112,7 @@ public abstract class AbstractTSCPair implements TimeSeriesCollectionPair {
         apply_lookback_(lookback);
     }
 
-    protected void update(DateTime ts, Stream<TimeSeriesValue> values, ExpressionLookBack lookback) {
+    protected void update(DateTime ts, Collection<TimeSeriesValue> values, ExpressionLookBack lookback) {
         if (!previous_.isEmpty()) {
             previous_.add(0, previous_.get(0).clone().merge(ts, values));  // Clone into position 0, so scrapes shared among classes remain unaffected.
         } else {
@@ -121,7 +122,7 @@ public abstract class AbstractTSCPair implements TimeSeriesCollectionPair {
     }
 
     protected void update(TimeSeriesCollection tsc, ExpressionLookBack lookback) {
-        update(tsc.getTimestamp(), tsc.getTSValues().stream(), lookback);
+        update(tsc.getTimestamp(), tsc.getTSValues(), lookback);
     }
 
     private void apply_lookback_(ExpressionLookBack lookback) {

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/BackRefTimeSeriesCollection.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/BackRefTimeSeriesCollection.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -38,6 +38,7 @@ import com.groupon.lex.metrics.NameCache;
 import com.groupon.lex.metrics.SimpleGroupPath;
 import gnu.trove.map.hash.THashMap;
 import java.util.Collection;
+import static java.util.Collections.unmodifiableCollection;
 import static java.util.Collections.unmodifiableSet;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -45,7 +46,6 @@ import java.util.Map;
 import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
@@ -135,8 +135,8 @@ public class BackRefTimeSeriesCollection implements TimeSeriesCollection {
     }
 
     @Override
-    public TimeSeriesValueSet getTSValues() {
-        return new TimeSeriesValueSet(data_.values().stream());
+    public Collection<TimeSeriesValue> getTSValues() {
+        return unmodifiableCollection(data_.values());
     }
 
     @Override
@@ -158,7 +158,7 @@ public class BackRefTimeSeriesCollection implements TimeSeriesCollection {
         return Optional.ofNullable(data_.get(name));
     }
 
-    public BackRefTimeSeriesCollection merge(DateTime timestamp, Stream<TimeSeriesValue> values) {
+    public BackRefTimeSeriesCollection merge(DateTime timestamp, Collection<TimeSeriesValue> values) {
         requireNonNull(values);
         timestamp_ = requireNonNull(timestamp);
 
@@ -179,7 +179,7 @@ public class BackRefTimeSeriesCollection implements TimeSeriesCollection {
     }
 
     public BackRefTimeSeriesCollection merge(MutableTimeSeriesCollection c) {
-        return merge(c.getTimestamp(), c.getData().values().stream());
+        return merge(c.getTimestamp(), c.getData().values());
     }
 
     @Override

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollection.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollection.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -37,6 +37,7 @@ import com.groupon.lex.metrics.MetricValue;
 import com.groupon.lex.metrics.SimpleGroupPath;
 import java.util.Collection;
 import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableCollection;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 import java.util.HashMap;
@@ -164,8 +165,8 @@ public class MutableTimeSeriesCollection implements TimeSeriesCollection, Clonea
     }
 
     @Override
-    public TimeSeriesValueSet getTSValues() {
-        return new TimeSeriesValueSet(data_.values().stream());
+    public Collection<TimeSeriesValue> getTSValues() {
+        return unmodifiableCollection(data_.values());
     }
 
     @Override

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollectionPairInstanceTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollectionPairInstanceTest.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -37,6 +37,7 @@ import com.groupon.lex.metrics.MetricValue;
 import com.groupon.lex.metrics.SimpleGroupPath;
 import static java.util.Collections.EMPTY_MAP;
 import static java.util.Collections.singletonMap;
+import java.util.HashSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -103,7 +104,7 @@ public class TimeSeriesCollectionPairInstanceTest {
         collection0.getData().values().forEach(ts_data.getCurrentCollection()::add);
 
         assertEquals(collection1.getTimestamp(), ts_data.getPreviousCollection().getTimestamp());
-        assertEquals(collection1.getTSValues(), ts_data.getPreviousCollection().getTSValues());
+        assertEquals(new HashSet<>(collection1.getTSValues()), new HashSet<>(ts_data.getPreviousCollection().getTSValues()));
         assertEquals(collection0, ts_data.getCurrentCollection());
     }
 

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollection.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -35,10 +35,13 @@ import com.groupon.lex.metrics.GroupName;
 import com.groupon.lex.metrics.MetricName;
 import com.groupon.lex.metrics.MetricValue;
 import com.groupon.lex.metrics.SimpleGroupPath;
+import java.util.ArrayList;
+import java.util.Collection;
 import static java.util.Collections.singletonMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -64,7 +67,7 @@ public interface TimeSeriesCollection extends Cloneable {
     public boolean isEmpty();
     public Set<GroupName> getGroups();
     public Set<SimpleGroupPath> getGroupPaths();
-    public TimeSeriesValueSet getTSValues();
+    public Collection<TimeSeriesValue> getTSValues();
     public TimeSeriesValueSet getTSValue(SimpleGroupPath name);
     public Optional<TimeSeriesValue> get(GroupName name);
 
@@ -72,6 +75,11 @@ public interface TimeSeriesCollection extends Cloneable {
         return get(name)
                 .map(Stream::of)
                 .map(TimeSeriesValueSet::new);
+    }
+
+    public default Map<SimpleGroupPath, Collection<TimeSeriesValue>> getTSValuesAsMap() {
+        return getTSValues().stream()
+                .collect(Collectors.groupingBy(tsv -> tsv.getGroup().getPath(), Collectors.toCollection(ArrayList::new)));
     }
 
     public TimeSeriesCollection clone();

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollection.java
@@ -35,13 +35,11 @@ import com.groupon.lex.metrics.GroupName;
 import com.groupon.lex.metrics.MetricName;
 import com.groupon.lex.metrics.MetricValue;
 import com.groupon.lex.metrics.SimpleGroupPath;
-import java.util.ArrayList;
 import java.util.Collection;
 import static java.util.Collections.singletonMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -75,11 +73,6 @@ public interface TimeSeriesCollection extends Cloneable {
         return get(name)
                 .map(Stream::of)
                 .map(TimeSeriesValueSet::new);
-    }
-
-    public default Map<SimpleGroupPath, Collection<TimeSeriesValue>> getTSValuesAsMap() {
-        return getTSValues().stream()
-                .collect(Collectors.groupingBy(tsv -> tsv.getGroup().getPath(), Collectors.toCollection(ArrayList::new)));
     }
 
     public TimeSeriesCollection clone();


### PR DESCRIPTION
- Instead of recreating the ``TimeSeriesValueSet`` each time, just expose the collection of values.
  This means no useless copy of the TimeSeriesValue ``Map`` internal to both ``TimeSeriesValueSet`` and ``TimeSeriesCollection``.

> - Also create ``getTSValuesAsMap()``, which groups by SimpleGroupPath.
>   (Not sure I like that function, especially as the only useage is in a test.)

Actually, I decided that ``getTSValuesAsMap()`` was a stupid function and erased it.