### PR TITLE
Make history context immutable.

### DIFF
--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/AbstractTSCPair.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/AbstractTSCPair.java
@@ -26,6 +26,12 @@ public abstract class AbstractTSCPair implements TimeSeriesCollectionPair {
     private static final Logger LOG = Logger.getLogger(AbstractTSCPair.class.getName());
     private List<BackRefTimeSeriesCollection> previous_ = new ArrayList<>();
 
+    protected AbstractTSCPair() {}
+
+    protected AbstractTSCPair(AbstractTSCPair original) {
+        original.previous_.forEach(previous_::add);
+    }
+
     public void initWithHistoricalData(CollectHistory history, ExpressionLookBack lookback) {
         if (!previous_.isEmpty()) {
             LOG.log(Level.WARNING, "skipping historical data initialization, as data is already present");


### PR DESCRIPTION
For some reason (streaming logic?) the history context would emit the same
context multiple times.  This probably is because the context was mutating
itself during iteration.  Make it immutable, so that any premature advancing
of the context won't cause it to emit the same context multiple times.

As an added bonus, this makes the history context concurrency-safe, i.e.
a stream that wants to parallellize evaluation will now be able to do so
correctly.

------------------------------------------------------------------------

My unconfirmed suspicion is that the stream does lazy evaluation of the
iterator return value.  Because ``/api/monsoon/eval`` uses a buffering
iterator for throughput, this means the context will have advanced
before the full evaluation of the metrics is complete.  Consequently,
multiple evaluations would hit the same context, thinking they were
different contexts.

I don't think this affected ``/api/monsoon/eval/gchart``, as that does
not buffer evaluations.