### PR TITLE
Make HTTP get collectors more lenient with slow servers.

### DIFF
--- a/http_get_collector/src/main/java/com/groupon/lex/metrics/collector/httpget/UrlGetCollector.java
+++ b/http_get_collector/src/main/java/com/groupon/lex/metrics/collector/httpget/UrlGetCollector.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -79,7 +79,7 @@ import org.joda.time.Interval;
  */
 public class UrlGetCollector implements GroupGenerator {
     private static final Logger LOG = Logger.getLogger(UrlGetCollector.class.getName());
-    public static final int TIMEOUT_SECONDS = 3;
+    public static final int TIMEOUT_SECONDS = 10;
     private final SimpleGroupPath base_group_name_;
     private final UrlPattern patterns_;
     private final RequestConfig request_config_ = RequestConfig.custom()

--- a/http_get_collector/src/main/java/com/groupon/lex/metrics/collector/httpget/UrlGetCollector.java
+++ b/http_get_collector/src/main/java/com/groupon/lex/metrics/collector/httpget/UrlGetCollector.java
@@ -80,6 +80,7 @@ import org.joda.time.Interval;
 public class UrlGetCollector implements GroupGenerator {
     private static final Logger LOG = Logger.getLogger(UrlGetCollector.class.getName());
     public static final int TIMEOUT_SECONDS = 10;
+    public static final int OVERALL_TIMEOUT_SECONDS = 30;
     private final SimpleGroupPath base_group_name_;
     private final UrlPattern patterns_;
     private final RequestConfig request_config_ = RequestConfig.custom()
@@ -302,7 +303,7 @@ public class UrlGetCollector implements GroupGenerator {
         return successResult(urls.stream()
                 .map(f -> {
                     try {
-                        return Optional.of(f.get(5, TimeUnit.SECONDS));
+                        return Optional.of(f.get(OVERALL_TIMEOUT_SECONDS, TimeUnit.SECONDS));
                     } catch (TimeoutException ex) {
                         LOG.log(Level.SEVERE, "Http Request never completed", ex);
                         f.cancel(true);


### PR DESCRIPTION
Bring timeouts for HTTP get collector in line with JMX collector:
both now abort after ~30 seconds.