### PR TITLE
Define tags

### DIFF
--- a/doc/rules/define.md
+++ b/doc/rules/define.md
@@ -7,12 +7,16 @@ A defined metric is useful to calculate information based off of gathered data a
 Syntax
 ----
 
-**define** group\_name metric **=** expression **;**
+**define** group\_name [ **tag** **(** tag\_name **=** tag\_expr [**,** ...]  **)** ] metric **=** expression **;**
 
 - *group\_name*
   The name of a group.
   The *metric* will be created inside this group.
   If the group doesn't exist, it will be created.
+- *tag\_name*
+  Add an additional tag to the defined metrics.
+- *tag\_expr*
+  An expression to resolve as the value of the tag.
 - *metric*
   The metric name in the group under which to expose the expression.
   If the *group* already holds a metric under this name, it will be replaced.

--- a/impl/src/main/java/com/groupon/lex/metrics/config/DerivedMetricStatement.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/config/DerivedMetricStatement.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -31,6 +31,7 @@
  */
 package com.groupon.lex.metrics.config;
 
+import com.groupon.lex.metrics.ConfigSupport;
 import com.groupon.lex.metrics.config.impl.DerivedMetricTransformerImpl;
 import com.groupon.lex.metrics.timeseries.TimeSeriesMetricExpression;
 import com.groupon.lex.metrics.timeseries.TimeSeriesTransformer;
@@ -44,14 +45,15 @@ import java.util.stream.Collectors;
  * @author ariane
  */
 public class DerivedMetricStatement implements RuleStatement {
+    private final static String INDENT = "    ";
     private final DerivedMetricTransformerImpl impl_;
 
     public DerivedMetricStatement(NameResolver group, NameResolver metric, TimeSeriesMetricExpression value_expr) {
         impl_ = new DerivedMetricTransformerImpl(group, metric, value_expr);
     }
 
-    public DerivedMetricStatement(NameResolver group, Map<NameResolver, TimeSeriesMetricExpression> metric_value_exprs) {
-        impl_ = new DerivedMetricTransformerImpl(group, metric_value_exprs);
+    public DerivedMetricStatement(NameResolver group, Map<String, TimeSeriesMetricExpression> tag_value_exprs, Map<NameResolver, TimeSeriesMetricExpression> metric_value_exprs) {
+        impl_ = new DerivedMetricTransformerImpl(group, tag_value_exprs, metric_value_exprs);
     }
 
     @Override
@@ -66,6 +68,16 @@ public class DerivedMetricStatement implements RuleStatement {
                 .append(impl_.getGroup().configString())
                 .append(' ');
 
+        if (!impl_.getTags().isEmpty()) {
+            sb.append(impl_.getTags().entrySet().stream()
+                    .map(tag_mapping -> {
+                        final String tagIdent = ConfigSupport.maybeQuoteIdentifier(tag_mapping.getKey()).toString();
+                        final String tagExpr = tag_mapping.getValue().configString().toString();
+                        return INDENT + tagIdent + " = " + tagExpr;
+                    })
+                    .collect(Collectors.joining(",\n", "tag (\n", "\n) ")));
+        }
+
         if (impl_.getMapping().size() == 1) {
             Map.Entry<NameResolver, TimeSeriesMetricExpression> entry = impl_.getMapping().entrySet().stream().findAny().get();
             sb
@@ -78,7 +90,11 @@ public class DerivedMetricStatement implements RuleStatement {
         } else {
             sb.append(impl_.getMapping().entrySet().stream()
                     .sorted(Comparator.comparing(entry -> entry.getKey().configString().toString()))
-                    .map(entry -> "    " + entry.getKey().configString() + " = " + entry.getValue().configString() + ";")
+                    .map(entry -> {
+                        final String metricName = entry.getKey().configString().toString();
+                        final String metricExpr = entry.getValue().configString().toString();
+                        return INDENT + metricName + " = " + metricExpr + ";";
+                    })
                     .collect(Collectors.joining("\n", "{\n", "\n}")));
         }
         return sb;

--- a/impl/src/main/java/com/groupon/lex/metrics/config/impl/DerivedMetricTransformerImpl.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/config/impl/DerivedMetricTransformerImpl.java
@@ -46,39 +46,27 @@ import com.groupon.lex.metrics.timeseries.expression.Context;
 import com.groupon.lex.metrics.transformers.NameResolver;
 import java.util.Collection;
 import static java.util.Collections.EMPTY_MAP;
-import static java.util.Collections.singletonMap;
-import static java.util.Collections.unmodifiableMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import lombok.Getter;
-import static java.util.Objects.requireNonNull;
+import lombok.NonNull;
+import lombok.Value;
 
 /**
  * Creates a new metric, by applying an expression.
  * @author ariane
  */
+@Value
 public class DerivedMetricTransformerImpl implements TimeSeriesTransformer {
-    @Getter
+    @NonNull
     private final NameResolver group;
-    @Getter
+    @NonNull
     private final Map<String, TimeSeriesMetricExpression> tags;
-    @Getter
+    @NonNull
     private final Map<NameResolver, TimeSeriesMetricExpression> mapping;
-
-    public DerivedMetricTransformerImpl(NameResolver group, NameResolver metric, TimeSeriesMetricExpression value_expr) {
-        this(group, EMPTY_MAP, singletonMap(requireNonNull(metric), requireNonNull(value_expr)));
-    }
-
-    public DerivedMetricTransformerImpl(NameResolver group, Map<String, TimeSeriesMetricExpression> tags, Map<NameResolver, TimeSeriesMetricExpression> mapping) {
-        this.group = requireNonNull(group);
-        this.tags = unmodifiableMap(new HashMap<>(requireNonNull(tags)));
-        this.mapping = unmodifiableMap(new HashMap<>(requireNonNull(mapping)));
-    }
 
     private static <T, U> Stream<Map.Entry<U, TimeSeriesMetricDeltaSet>> resolveMapping(Context ctx, Map<T, TimeSeriesMetricExpression> mapping, Function<? super T, Optional<? extends U>> key_mapper_) {
         return mapping.entrySet().stream()
@@ -136,36 +124,6 @@ public class DerivedMetricTransformerImpl implements TimeSeriesTransformer {
                                         .addMetric(grp, metric, tsdelta);
                             });
                 });
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = 5;
-        hash = 61 * hash + Objects.hashCode(this.group);
-        hash = 61 * hash + Objects.hashCode(this.tags);
-        hash = 61 * hash + Objects.hashCode(this.mapping);
-        return hash;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final DerivedMetricTransformerImpl other = (DerivedMetricTransformerImpl) obj;
-        if (!Objects.equals(this.group, other.group)) {
-            return false;
-        }
-        if (!Objects.equals(this.tags, other.tags)) {
-            return false;
-        }
-        if (!Objects.equals(this.mapping, other.mapping)) {
-            return false;
-        }
-        return true;
     }
 
     @Override


### PR DESCRIPTION
Allows defining tags during a define statement.

Example:

    define my.group tag(instance = sample.metric app_name) {
        cpu = sample.metric cpu;
        mem = sample.metric mem;
    }