### PR TITLE
Implement name() function.

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -69,6 +69,8 @@ Most simple arithmatic and boolean logic has been implemented.
   Describes the percentile aggregate.
 - [str function](expressions/str.md)
   Describes the string concatenation function.
+- [name function](expressions/name.md)
+  Describes the name function, that takes (part of) a (group/metric) name and returns it as a metric value.
 - [rate function](expressions/rate.md)
   Describes the rate function, which is used to convert a monotonic increasing counter into a rate per second value.
 - [regexp function(expressions/regexp.md)

--- a/doc/expressions/name.md
+++ b/doc/expressions/name.md
@@ -1,0 +1,46 @@
+Expression: Name function
+====
+
+The ``name`` function is used to evaluate a resolved name.
+
+Syntax
+----
+
+**name** **(** selector **)**
+
+- *selector*
+  A (group or metric) name.
+  The group/metric does not have to exist.
+
+The function will evaluate the name and try to coerce the name into a sensible value.
+- ``true`` and ``false`` will be turned into their boolean counterparts.
+- *numbers* will be evaluated into numeric values.
+- *strings* will be evaluated into strings.
+- *paths with multiple components* will have their path components concatenated, separated by dots (``.``).
+
+Example
+----
+
+    name(example.metric.name)                                          # (1)
+    name('true')                                                       # (2)
+    name('17')                                                         # (3)
+    name('0.314e1')                                                    # (4)
+    name('0xff')                                                       # (5)
+
+1. Yields the metric value ``"example.metric.name"``.
+2. Yields the metric value ``true`` (a boolean).
+3. Yields the metric value ``17`` (an integral number).
+4. Yields the metric value ``3.14`` (a floating point number).
+5. Yields the metric value ``255`` (an integral number, interpreted in hexadecimal notation).
+
+This is very powerful to use with match statements, for instance:
+
+    match example.*.metric.name as G {
+        tag G as index = name(G[1]);
+    }
+
+This will take the second component of ``example.*.metric.name`` and assign it as a tag to that metric.  
+For example:
+
+- ``example.'4'.metric.name`` will be tagged as ``example.'4'.metric.name{ index = 4 }``.
+- ``example.foobar.metric.name`` will be tagged as ``example.'4'.metric.name{ index = "foobar" }``.

--- a/impl/src/main/antlr4/imports/ConfigBnf.g4
+++ b/impl/src/main/antlr4/imports/ConfigBnf.g4
@@ -803,6 +803,7 @@ function_invocation returns [ TimeSeriesMetricExpression s ]
                    | { $fn.getText().equals("str")            }? s_fn__str=fn__str         { expr = $s_fn__str.s;     }
                    | { $fn.getText().equals("regexp")         }? s_fn__regexp=fn__regexp   { expr = $s_fn__regexp.s;  }
                    | { $fn.getText().equals("percentile_agg") }? s_fn__pct_agg=fn__pct_agg { expr = $s_fn__pct_agg.s; }
+                   | { $fn.getText().equals("name")           }? s_fn__name=fn__name       { expr = $s_fn__name.s;    }
                    )
                    | TAG_KW BRACE_OPEN_LIT                       s_fn__tag=fn__tag         { expr = $s_fn__tag.s;     }
                  ;
@@ -860,6 +861,11 @@ fn__regexp       returns [ TimeSeriesMetricExpression s ]
                    | s_regexp_re=regex{ regexp = $s_regexp_re.s; }
                    ) COMMA_LIT
                    s_replacement=quoted_string
+                   BRACE_CLOSE_LIT
+                 ;
+fn__name         returns [ TimeSeriesMetricExpression s ]
+                 @after{ $s = new NameExpression($s_name.s); }
+                 : s_name=name
                    BRACE_CLOSE_LIT
                  ;
 

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/expression/NameExpression.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/expression/NameExpression.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics.timeseries.expression;
+
+import com.groupon.lex.metrics.MetricValue;
+import com.groupon.lex.metrics.Path;
+import com.groupon.lex.metrics.timeseries.TimeSeriesMetricDeltaSet;
+import com.groupon.lex.metrics.timeseries.TimeSeriesMetricExpression;
+import static com.groupon.lex.metrics.timeseries.expression.Priorities.BRACKETS;
+import com.groupon.lex.metrics.transformers.NameResolver;
+import java.util.Collection;
+import static java.util.Collections.EMPTY_LIST;
+import java.util.List;
+import lombok.NonNull;
+import lombok.Value;
+
+/**
+ * Invoke a name resolver and convert its result to a metric value.
+ *
+ * If the Name Resolver yields:
+ * - [ "true" ] --> yield a boolean true value
+ * - [ "false" ] --> yield a boolean false value
+ * - [ integral-number] --> yield a metric value representing the number
+ * - [ FP-number ] --> yield a metric value representing the number
+ * - anything else --> yield a String metric value, separating components by dots ('.').
+ */
+@Value
+public class NameExpression implements TimeSeriesMetricExpression {
+    @NonNull
+    private final NameResolver resolver;
+
+    private static MetricValue strAsMetricValue(String str) {
+        // Try to coerce elem to a boolean.
+        if ("true".equals(str)) return MetricValue.TRUE;
+        if ("false".equals(str)) return MetricValue.FALSE;
+        // Try to coerce elem to an integral number.
+        try {
+            return MetricValue.fromIntValue(Long.parseLong(str));
+        } catch (NumberFormatException e) {
+            // Ignore.
+        }
+        // Try to coerce elem to a floating point number.
+        try {
+            return MetricValue.fromDblValue(Double.parseDouble(str));
+        } catch (NumberFormatException e) {
+            // Ignore.
+        }
+        // Give up and just yield a string.
+        return MetricValue.fromStrValue(str);
+    }
+
+    private static MetricValue pathAsMetricValue(Path path) {
+        final List<String> pathElems = path.getPath();
+        if (pathElems.size() == 1) return strAsMetricValue(pathElems.get(0));
+        return MetricValue.fromStrValue(String.join(".", pathElems));
+    }
+
+    @Override
+    public TimeSeriesMetricDeltaSet apply(Context ctx) {
+        return resolver.apply(ctx)
+                .map(NameExpression::pathAsMetricValue)
+                .map(TimeSeriesMetricDeltaSet::new)
+                .orElseGet(TimeSeriesMetricDeltaSet::new);
+    }
+
+    @Override
+    public Collection<TimeSeriesMetricExpression> getChildren() {
+        return EMPTY_LIST;
+    }
+
+    @Override
+    public int getPriority() {
+        return BRACKETS;
+    }
+
+    @Override
+    public StringBuilder configString() {
+        return new StringBuilder()
+                .append("name(")
+                .append(resolver.configString())
+                .append(')');
+    }
+}

--- a/impl/src/test/java/com/groupon/lex/metrics/config/parser/FunctionTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/config/parser/FunctionTest.java
@@ -366,4 +366,14 @@ public class FunctionTest extends AbstractAlertTest {
                     OK, OK, OK, UNKNOWN, UNKNOWN));
         }
     }
+
+    @Test
+    public void name_expr() throws Exception {
+        try (AbstractAlertTest.AlertValidator impl = replay("alert test if "
+                + "name(" + TESTGROUP.configString() + ") != " + TESTGROUP.configString() + " expected;", 60,
+                newDatapoint(TESTGROUP, "expected", String.join(".", TESTGROUP.getPath().getPath())))) {
+            impl.validate(newDatapoint(GroupName.valueOf("test"),
+                    OK));
+        }
+    }
 }


### PR DESCRIPTION
``name()`` takes a path name and converts it to a metric value.

Examples:

    name(com.groupon.lex.monsoon) = "com.groupon.lex.monsoon"
    name('17') = 17
    name('true') = true
    name('false') = false

This can be used in combination with match statement and the tagged-define (https://github.com/groupon/monsoon/pull/23) for instance:

    match url.loaded.metrics body.instance.*.name as G, Name {
        define ${G}.instance
        tag (name = Name, instance = name(${Name[3]})) {
            count = G ${M[:3]}.count;
        }
    }
