### PR TITLE
Range resolver

### DIFF
--- a/impl/src/main/java/com/groupon/lex/metrics/resolver/RangeResolver.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/resolver/RangeResolver.java
@@ -3,48 +3,50 @@ package com.groupon.lex.metrics.resolver;
 import static com.groupon.lex.metrics.resolver.ResolverTuple.newTupleElement;
 import static java.lang.Integer.max;
 import java.util.ArrayList;
-import java.util.Collection;
+import static java.util.Collections.unmodifiableList;
 import java.util.List;
-import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 
 /**
  * A resolver that emits a range of numbers.
+ *
+ * Bounds are inclusive.
  */
 @Getter
-@AllArgsConstructor
+@ToString
+@EqualsAndHashCode
 public class RangeResolver implements Resolver {
     private final int begin, end;
+    private final List<ResolverTuple> tuples;
 
-    public RangeResolver(int end) {
-        this(0, end);
+    public RangeResolver(int begin, int end) {
+        this.begin = begin;
+        this.end = end;
+        this.tuples = createTuples(begin, end);
     }
 
     @Override
-    public int getTupleWidth() {
-        return 1;
-    }
-
+    public int getTupleWidth() { return 1; }
     @Override
-    public Collection<ResolverTuple> getTuples() {
-        List<ResolverTuple> tuples = new ArrayList<>(max(end - begin, 0));
+    public String configString() { return begin + ".." + end; }
+
+    private static List<ResolverTuple> createTuples(int begin, int end) {
+        final ArrayList<ResolverTuple> tuples = new ArrayList<>(max(end - begin + 1, 0));
+
+        /*
+         * We need a for-loop: for (int i = begin; i <= end; ++i) { ... }
+         * But this won't work if end == Integer.MAX_VALUE, since i can never
+         * exceed Integer.MAX_VALUE (wrapping around to Integer.MIN_VALUE
+         * instead).
+         * So the equals-case is handled separately in an if-statement below.
+         */
         for (int i = begin; i < end; ++i)
             tuples.add(new ResolverTuple(newTupleElement(i)));
-        return tuples;
-    }
+        if (end >= begin)
+            tuples.add(new ResolverTuple(newTupleElement(end)));
 
-    @Override
-    public String configString() {
-        StringBuilder buf = new StringBuilder()
-                .append("range(");
-        if (begin != 0) {
-            buf
-                    .append(begin)
-                    .append(", ");
-        }
-        return buf
-                .append(end)
-                .append(')')
-                .toString();
+        return unmodifiableList(tuples);
     }
 }

--- a/impl/src/test/java/com/groupon/lex/metrics/resolver/RangeResolverTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/resolver/RangeResolverTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics.resolver;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class RangeResolverTest {
+    @Test
+    public void values() {
+        RangeResolver range = new RangeResolver(-1, 1);
+
+        assertEquals(1, range.getTupleWidth());
+        assertEquals(-1, range.getBegin());
+        assertEquals(1, range.getEnd());
+        assertThat(range.getTuples(),
+                containsInAnyOrder(
+                        new ResolverTuple(ResolverTuple.newTupleElement(-1)),
+                        new ResolverTuple(ResolverTuple.newTupleElement(0)),
+                        new ResolverTuple(ResolverTuple.newTupleElement(1))));
+        assertEquals("-1..1", range.configString());
+    }
+
+    @Test
+    public void negativeRange() {
+        RangeResolver range = new RangeResolver(1, -1);
+
+        assertEquals(1, range.getTupleWidth());
+        assertEquals(1, range.getBegin());
+        assertEquals(-1, range.getEnd());
+        assertTrue(range.getTuples().isEmpty());
+        assertEquals("1..-1", range.configString());
+    }
+
+    @Test
+    public void singleElementRange() {
+        RangeResolver range = new RangeResolver(17, 17);
+
+        assertEquals(1, range.getTupleWidth());
+        assertEquals(17, range.getBegin());
+        assertEquals(17, range.getEnd());
+        assertThat(range.getTuples(),
+                containsInAnyOrder(
+                        new ResolverTuple(ResolverTuple.newTupleElement(17))));
+        assertEquals("17..17", range.configString());
+    }
+
+    @Test
+    public void intMinValue() {
+        RangeResolver range = new RangeResolver(Integer.MIN_VALUE, Integer.MIN_VALUE);
+
+        assertEquals(1, range.getTupleWidth());
+        assertEquals(Integer.MIN_VALUE, range.getBegin());
+        assertEquals(Integer.MIN_VALUE, range.getEnd());
+        assertThat(range.getTuples(),
+                containsInAnyOrder(
+                        new ResolverTuple(ResolverTuple.newTupleElement(Integer.MIN_VALUE))));
+        assertEquals(Integer.MIN_VALUE + ".." + Integer.MIN_VALUE, range.configString());
+    }
+
+    @Test
+    public void intMaxValue() {
+        RangeResolver range = new RangeResolver(Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+        assertEquals(1, range.getTupleWidth());
+        assertEquals(Integer.MAX_VALUE, range.getBegin());
+        assertEquals(Integer.MAX_VALUE, range.getEnd());
+        assertThat(range.getTuples(),
+                containsInAnyOrder(
+                        new ResolverTuple(ResolverTuple.newTupleElement(Integer.MAX_VALUE))));
+        assertEquals(Integer.MAX_VALUE + ".." + Integer.MAX_VALUE, range.configString());
+    }
+}


### PR DESCRIPTION
I'm not entirely sure about the configuration form, yet.

Currently, it's:

    tupleKey = 1..100

which generates the numbers 1, 2, 3, ..., 98, 99, 100.
Note the absence of square brackets.

Numbers must be valid signed integers (INT_MIN to INT_MAX).
The code has been tested to do the right thing with INT_MIN and/or INT_MAX.
Although supplying the entire range of integers does require a lot of memory.

----

I'm debating if I should enable this in tuples, for example:

    (key1, key2) = [
        ("somehost",  6000..6009),
        ("otherhost", 6010..6019),
        ...
    ]

which might be a nice way to supply port ranges, for instance.

----

I'm debating if I should enable this in lists too:

    tupleKey = [ 80, 443, 8000..8080 ]

which might be a nice way to add a lot of numbers quickly.