### PR TITLE
Async resolver

### DIFF
--- a/impl/src/main/java/com/groupon/lex/metrics/resolver/CachingResolver.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/resolver/CachingResolver.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics.resolver;
+
+import static com.groupon.lex.metrics.ConfigSupport.durationConfigString;
+import java.util.Collection;
+import static java.util.Collections.EMPTY_LIST;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import lombok.NonNull;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+
+public class CachingResolver implements Resolver {
+    private static enum Refresh {
+        REUSE,
+        MAY_REFRESH,
+        MUST_REFRESH
+    }
+
+    private static final Logger LOG = Logger.getLogger(CachingResolver.class.getName());
+    /** Scheduler used for async resolution. */
+    private static final ScheduledExecutorService SCHEDULER;
+    /** Time until next attempt to reload tuples, after a failed reload attempt. */
+    private static final int FAILURE_RESCHEDULE_DELAY = 5000;
+    private final AsyncResolver underlying;
+    private final Duration minAge, maxAge;
+    private DateTime lastRefresh;
+    private Collection<ResolverTuple> tuples = EMPTY_LIST;
+    private Throwable exception = null;
+    private CompletableFuture<?> currentFut = null;
+    private boolean closed = false;
+
+    static {
+        final AtomicInteger thrIndex = new AtomicInteger();
+
+        final ScheduledThreadPoolExecutor scheduler = new ScheduledThreadPoolExecutor(1,
+                (Runnable r) -> {
+                    final Thread thr = new Thread(r);
+                    thr.setName("CachingResolver-worker-" + thrIndex.getAndIncrement());
+                    thr.setDaemon(true);
+                    return thr;
+                });
+        scheduler.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+        scheduler.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+        scheduler.setKeepAliveTime(5, TimeUnit.MINUTES);
+        scheduler.setMaximumPoolSize(4);
+        SCHEDULER = scheduler;
+    }
+
+    public CachingResolver(@NonNull AsyncResolver underlying, @NonNull Duration minAge, @NonNull Duration maxAge) {
+        this.underlying = underlying;
+        this.minAge = minAge;
+        this.maxAge = maxAge;
+        this.lastRefresh = null;
+
+        refresh();
+    }
+
+    public CachingResolver(@NonNull Resolver underlying, @NonNull Duration minAge, @NonNull Duration maxAge) {
+        this(AsyncResolver.makeAsync(underlying), minAge, maxAge);
+    }
+
+    @Override
+    public int getTupleWidth() {
+        return underlying.getTupleWidth();
+    }
+
+    @Override
+    public synchronized Collection<ResolverTuple> getTuples() throws Exception {
+        if (closed) throw new IllegalStateException("resolver is closed");
+
+        final Refresh refresh = getRefresh();
+        Collection<ResolverTuple> result;
+        switch (refresh) {
+            case REUSE:
+            case MAY_REFRESH:
+                result = tuples;
+                break;
+            case MUST_REFRESH:
+                if (exception == null)
+                    throw new StaleResolverException();
+                else
+                    throw new StaleResolverException(exception);
+            default:
+                assert(false);
+                throw new IllegalStateException("unreachable statement");
+        }
+        return result;
+    }
+
+    @Override
+    public String configString() {
+        return underlying.configString() + "[" + durationConfigString(minAge) + " - " + durationConfigString(maxAge) + " ]";
+    }
+
+    @Override
+    public synchronized void close() {
+        closed = true;
+        if (currentFut != null) {
+            currentFut.cancel(false);
+            currentFut = null;
+        }
+    }
+
+    private synchronized Refresh getRefresh() {
+        if (lastRefresh == null) return Refresh.MUST_REFRESH;
+        final DateTime mayTP = lastRefresh.plus(minAge), mustTP = lastRefresh.plus(maxAge);
+        final DateTime now = DateTime.now();
+
+        if (now.isAfter(mustTP)) return Refresh.MUST_REFRESH;
+        if (now.isAfter(mayTP)) return Refresh.MAY_REFRESH;
+        return Refresh.REUSE;
+    }
+
+    /**
+     * Attempt to refresh the resolver result.
+     * @return a boolean, with true indicating success and false indicating failure.
+     */
+    private void refresh() {
+        try {
+            // Invoke underlying getTuples unsynchronized.
+            // This way it won't block tuple access, in case it is a long
+            // running or expensive function.
+            final CompletableFuture<? extends Collection<ResolverTuple>> fut = underlying.getTuples();
+
+            // Publish future, needs synchronization, so close() method can cancel properly.
+            synchronized(this) {
+                if (closed) {  // Close may have set close bit while we were creating future.
+                    fut.cancel(false);
+                } else {
+                    // We create the whenCompleteAsync continuation with synchronization locked,
+                    // because the update code will want to clear the currentFut member-variable.
+                    // We must ensure it is set before.
+                    currentFut = fut.whenCompleteAsync(this::update, SCHEDULER);
+                }
+            }
+        } catch (Exception ex) {
+            synchronized(this) {
+                exception = ex;
+            }
+            reschedule(FAILURE_RESCHEDULE_DELAY);
+        }
+    }
+
+    /** Update callback, called when the completable future completes. */
+    private void update(Collection<ResolverTuple> underlyingTuples, Throwable t) {
+        if (t != null)
+            applyException(t);
+        else if (underlyingTuples != null)
+            applyUpdate(underlyingTuples);
+        else
+            applyException(null);
+    }
+
+    /** Apply updated tuple collection. */
+    private synchronized void applyUpdate(Collection<ResolverTuple> underlyingTuples) {
+        lastRefresh = DateTime.now();
+        tuples = underlyingTuples;
+        exception = null;
+        reschedule(minAge.getMillis());
+    }
+
+    /**
+     * Update the exception of the last refresh attempt.
+     * The last refresh exception is used as a cause for StaleException.
+     */
+    private synchronized void applyException(Throwable t) {
+        exception = t;
+        reschedule(FAILURE_RESCHEDULE_DELAY);
+    }
+
+    /** Schedule next invocation of the update task. */
+    private synchronized void reschedule(long millis) {
+        currentFut = null;  // Remove current future.
+
+        if (!closed) {
+            SCHEDULER.schedule(this::refresh, millis, TimeUnit.MILLISECONDS);
+        } else {
+            try {
+                underlying.close();
+            } catch (Exception ex) {
+                LOG.log(Level.WARNING, "failed to close resolver " + underlying.configString(), ex);
+            }
+        }
+    }
+
+    public static class StaleResolverException extends Exception {
+        public StaleResolverException() { super("stale resolver"); }
+        public StaleResolverException(Throwable cause) { super("stale resolver", cause); }
+    }
+}

--- a/impl/src/test/java/com/groupon/lex/metrics/config/JmxListenerMonitorTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/config/JmxListenerMonitorTest.java
@@ -196,9 +196,12 @@ public class JmxListenerMonitorTest {
         when(nbr.resolve()).then(invocation -> Stream.of(EMPTY_MAP));
 
         mon_oneName.apply(mri);
+        listeners.forEach(GroupGenerator::getGroups);  // Force creation of JMX collectors
 
         assertThat(listeners,
-                contains(listener("localhost", "9999", one_name, EMPTY_LIST, Tags.EMPTY)));
+                contains(
+                        Matchers.hasProperty("currentGenerators", contains(
+                                listener("localhost", "9999", one_name, EMPTY_LIST, Tags.EMPTY)))));
 
         verify(nbr, times(1)).resolve();
         verify(mri, times(1)).add(Mockito.any());
@@ -210,9 +213,12 @@ public class JmxListenerMonitorTest {
         when(nbr.resolve()).then(invocation -> Stream.of(EMPTY_MAP));
 
         mon_twoNames.apply(mri);
+        listeners.forEach(GroupGenerator::getGroups);  // Force creation of JMX collectors
 
         assertThat(listeners,
-                contains(listener("localhost", "9999", two_names, EMPTY_LIST, Tags.EMPTY)));
+                contains(
+                        Matchers.hasProperty("currentGenerators", contains(
+                                listener("localhost", "9999", two_names, EMPTY_LIST, Tags.EMPTY)))));
 
         verify(nbr, times(1)).resolve();
         verify(mri, times(1)).add(Mockito.any());
@@ -234,23 +240,26 @@ public class JmxListenerMonitorTest {
                 }}));
 
         mon_oneName.apply(mri);
+        listeners.forEach(GroupGenerator::getGroups);  // Force creation of JMX collectors
 
         assertThat(listeners,
-                containsInAnyOrder(
-                        listener("other.host", "99", one_name, EMPTY_LIST, Tags.valueOf(new HashMap<String, MetricValue>() {{
-                            put("host", MetricValue.fromStrValue("other.host"));
-                            put("port", MetricValue.fromIntValue(99));
-                            put("extra_tag", MetricValue.fromStrValue("foobar"));
-                        }})),
-                        listener("localhost", "90", one_name, EMPTY_LIST, Tags.valueOf(new HashMap<String, MetricValue>() {{
-                            put("host", MetricValue.fromStrValue("localhost"));
-                            put("port", MetricValue.fromStrValue("90"));
-                            put("extra_tag", MetricValue.TRUE);
-                        }}))
+                contains(
+                        Matchers.hasProperty("currentGenerators", containsInAnyOrder(
+                                listener("other.host", "99", one_name, EMPTY_LIST, Tags.valueOf(new HashMap<String, MetricValue>() {{
+                                    put("host", MetricValue.fromStrValue("other.host"));
+                                    put("port", MetricValue.fromIntValue(99));
+                                    put("extra_tag", MetricValue.fromStrValue("foobar"));
+                                }})),
+                                listener("localhost", "90", one_name, EMPTY_LIST, Tags.valueOf(new HashMap<String, MetricValue>() {{
+                                    put("host", MetricValue.fromStrValue("localhost"));
+                                    put("port", MetricValue.fromStrValue("90"));
+                                    put("extra_tag", MetricValue.TRUE);
+                                }}))
+                        ))
                 ));
 
         verify(nbr, times(1)).resolve();
-        verify(mri, times(2)).add(Mockito.any());
+        verify(mri, times(1)).add(Mockito.any());
         verifyNoMoreInteractions(mri, nbr);
     }
 
@@ -269,21 +278,24 @@ public class JmxListenerMonitorTest {
                 }}));
 
         mon_twoNames.apply(mri);
+        listeners.forEach(GroupGenerator::getGroups);  // Force creation of JMX collectors
 
         assertThat(listeners,
-                containsInAnyOrder(
-                        listener("other.host", "99", two_names, singletonList("foobar"), Tags.valueOf(new HashMap<String, MetricValue>() {{
-                            put("host", MetricValue.fromStrValue("other.host"));
-                            put("port", MetricValue.fromIntValue(99));
-                        }})),
-                        listener("localhost", "90", two_names, singletonList("foobar"), Tags.valueOf(new HashMap<String, MetricValue>() {{
-                            put("host", MetricValue.fromStrValue("localhost"));
-                            put("port", MetricValue.fromStrValue("90"));
-                        }}))
+                contains(
+                        Matchers.hasProperty("currentGenerators", containsInAnyOrder(
+                                listener("other.host", "99", two_names, singletonList("foobar"), Tags.valueOf(new HashMap<String, MetricValue>() {{
+                                    put("host", MetricValue.fromStrValue("other.host"));
+                                    put("port", MetricValue.fromIntValue(99));
+                                }})),
+                                listener("localhost", "90", two_names, singletonList("foobar"), Tags.valueOf(new HashMap<String, MetricValue>() {{
+                                    put("host", MetricValue.fromStrValue("localhost"));
+                                    put("port", MetricValue.fromStrValue("90"));
+                                }}))
+                        ))
                 ));
 
         verify(nbr, times(1)).resolve();
-        verify(mri, times(2)).add(Mockito.any());
+        verify(mri, times(1)).add(Mockito.any());
         verifyNoMoreInteractions(mri, nbr);
     }
 

--- a/intf/src/main/java/com/groupon/lex/metrics/ResolverGroupGenerator.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/ResolverGroupGenerator.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics;
+
+import static com.groupon.lex.metrics.GroupGenerator.failedResult;
+import static com.groupon.lex.metrics.GroupGenerator.successResult;
+import com.groupon.lex.metrics.lib.Any2;
+import com.groupon.lex.metrics.lib.Any3;
+import com.groupon.lex.metrics.resolver.NameBoundResolver;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import static java.util.Objects.requireNonNull;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A group generator that manages GroupGenerators based on the active resolver.
+ *
+ * When a group generator does not exist, for a given argument set,
+ * it will create one.
+ * When the resolver does not return a given argument set, the associated
+ * group generator will be closed.
+ */
+@RequiredArgsConstructor
+public class ResolverGroupGenerator implements GroupGenerator {
+    private static final Logger LOG = Logger.getLogger(ResolverGroupGenerator.class.getName());
+    private final Map<Map<Any2<Integer, String>, Any3<Boolean, Integer, String>>, GroupGenerator> generators = new HashMap<>();
+    @NonNull
+    private final NameBoundResolver resolver;
+    @NonNull
+    private final GroupGeneratorFactory createGenerator;
+
+    @Override
+    public GroupCollection getGroups() {
+        final Set<Map<Any2<Integer, String>, Any3<Boolean, Integer, String>>> resolvedMaps;
+
+        try {
+            resolvedMaps = resolver.resolve().collect(Collectors.toSet());
+        } catch (Exception ex) {
+            LOG.log(Level.WARNING, "unable to resolve", ex);
+            return failedResult();
+        }
+
+        // Close all generators that are not to run.
+        final Iterator<Map.Entry<Map<Any2<Integer, String>, Any3<Boolean, Integer, String>>, GroupGenerator>> genIter = generators.entrySet().iterator();
+        while (genIter.hasNext()) {
+            final Map.Entry<Map<Any2<Integer, String>, Any3<Boolean, Integer, String>>, GroupGenerator> gen = genIter.next();
+            if (!resolvedMaps.contains(gen.getKey())) {
+                final GroupGenerator toBeClosed = gen.getValue();
+                genIter.remove();
+                try {
+                    toBeClosed.close();
+                } catch (Exception ex) {
+                    LOG.log(Level.WARNING, "unable to close " + toBeClosed, ex);
+                }
+            }
+        }
+
+        // Create missing generators.
+        resolvedMaps.removeAll(generators.keySet());
+        for (Map<Any2<Integer, String>, Any3<Boolean, Integer, String>> resolvedMap : resolvedMaps) {
+            try {
+                generators.put(resolvedMap, requireNonNull(createGenerator.create(resolvedMap)));
+            } catch (Exception ex) {
+                LOG.log(Level.WARNING, "unable to create generator", ex);
+                return failedResult();
+            }
+        }
+
+        // Evaluate all generators.
+        final List<GroupCollection> results = new ArrayList<>(generators.size());
+        for (GroupGenerator generator : generators.values()) {
+            final GroupCollection groups = generator.getGroups();
+            if (!groups.isSuccessful()) return failedResult();
+            results.add(groups);
+        }
+        return successResult(results.stream()
+                .map(GroupCollection::getGroups)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    public void close() throws Exception {
+        Exception thrown = null;
+
+        try {
+            resolver.close();
+        } catch (Exception ex) {
+            LOG.log(Level.WARNING, "unable to close resolver " + resolver, ex);
+            if (thrown == null)
+                thrown = ex;
+            else
+                thrown.addSuppressed(ex);
+        }
+
+        for (GroupGenerator generator : generators.values()) {
+            try {
+                generator.close();
+            } catch (Exception ex) {
+                LOG.log(Level.WARNING, "unable to close generator " + generator, ex);
+                if (thrown == null)
+                    thrown = ex;
+                else
+                    thrown.addSuppressed(ex);
+            }
+        }
+        generators.clear();
+
+        if (thrown != null) throw thrown;
+    }
+
+    public static interface GroupGeneratorFactory {
+        public GroupGenerator create(Map<Any2<Integer, String>, Any3<Boolean, Integer, String>> args) throws Exception;
+    }
+}

--- a/intf/src/main/java/com/groupon/lex/metrics/ResolverGroupGenerator.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/ResolverGroupGenerator.java
@@ -38,6 +38,7 @@ import com.groupon.lex.metrics.lib.Any3;
 import com.groupon.lex.metrics.resolver.NameBoundResolver;
 import java.util.ArrayList;
 import java.util.Collection;
+import static java.util.Collections.unmodifiableCollection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -47,6 +48,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
@@ -63,9 +65,15 @@ public class ResolverGroupGenerator implements GroupGenerator {
     private static final Logger LOG = Logger.getLogger(ResolverGroupGenerator.class.getName());
     private final Map<Map<Any2<Integer, String>, Any3<Boolean, Integer, String>>, GroupGenerator> generators = new HashMap<>();
     @NonNull
+    @Getter
     private final NameBoundResolver resolver;
     @NonNull
+    @Getter
     private final GroupGeneratorFactory createGenerator;
+
+    public Collection<GroupGenerator> getCurrentGenerators() {
+        return unmodifiableCollection(generators.values());
+    }
 
     @Override
     public GroupCollection getGroups() {

--- a/intf/src/main/java/com/groupon/lex/metrics/resolver/AsyncResolver.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/resolver/AsyncResolver.java
@@ -1,0 +1,44 @@
+package com.groupon.lex.metrics.resolver;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import lombok.NonNull;
+
+/**
+ * A resolver, used in import statements to generate data on the fly.
+ *
+ * Resolvers return tuples of a fixed length.
+ */
+public interface AsyncResolver extends AutoCloseable {
+    /** Returns the number of elements per tuple. */
+    public int getTupleWidth();
+    /** Resolves tuples. */
+    public CompletableFuture<? extends Collection<ResolverTuple>> getTuples() throws Exception;
+
+    public String configString();
+    @Override
+    public default void close() throws Exception {}
+
+    public static AsyncResolver makeAsync(@NonNull Resolver resolver) {
+        return new AsyncResolver() {
+            @Override
+            public int getTupleWidth() { return resolver.getTupleWidth(); }
+            @Override
+            public String configString() { return resolver.configString(); }
+
+            @Override
+            public CompletableFuture<Collection<ResolverTuple>> getTuples() {
+                try {
+                    return CompletableFuture.completedFuture(resolver.getTuples());
+                } catch (Exception ex) {
+                    final CompletableFuture<Collection<ResolverTuple>> failFut = new CompletableFuture<>();
+                    failFut.completeExceptionally(ex);
+                    return failFut;
+                }
+            }
+
+            @Override
+            public void close() throws Exception { resolver.close(); }
+        };
+    }
+}

--- a/intf/src/main/java/com/groupon/lex/metrics/resolver/NameBoundResolver.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/resolver/NameBoundResolver.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public interface NameBoundResolver {
+public interface NameBoundResolver extends AutoCloseable {
     public static final NameBoundResolver EMPTY = new NameBoundResolver() {
         @Override
         public Stream<Map<Any2<Integer, String>, Any3<Boolean, Integer, String>>> resolve() { return Stream.of(EMPTY_MAP); }
@@ -19,6 +19,8 @@ public interface NameBoundResolver {
         public boolean isEmpty() { return true; }
         @Override
         public String configString() { return ""; }
+        @Override
+        public void close() {}
     };
 
     public Stream<Map<Any2<Integer, String>, Any3<Boolean, Integer, String>>> resolve() throws Exception;

--- a/intf/src/main/java/com/groupon/lex/metrics/resolver/Resolver.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/resolver/Resolver.java
@@ -7,11 +7,13 @@ import java.util.Collection;
  *
  * Resolvers return tuples of a fixed length.
  */
-public interface Resolver {
+public interface Resolver extends AutoCloseable {
     /** Returns the number of elements per tuple. */
     public int getTupleWidth();
     /** Resolves tuples. */
     public Collection<ResolverTuple> getTuples() throws Exception;
 
     public String configString();
+    @Override
+    public default void close() throws Exception {}
 }

--- a/intf/src/main/java/com/groupon/lex/metrics/resolver/SimpleBoundNameResolver.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/resolver/SimpleBoundNameResolver.java
@@ -95,4 +95,9 @@ public class SimpleBoundNameResolver implements NameBoundResolver {
                     .collect(nameJoiner);
         }
     }
+
+    @Override
+    public void close() throws Exception {
+        resolver.close();
+    }
 }


### PR DESCRIPTION
Create asynchronous resolver utilities.

Asynchronous resolvers:
- are refreshed after a given ``minAge`` interval.
- are considered stale after a given ``maxAge`` interval.
- are refreshed in a background thread, to prevent delaying the application.

Create ``ResolverGroupGenerator``, which keeps track of multiple resolvers (one per argument map).
- it creates new GroupGenerators when appropriate.
- it closes GroupGenerators it no longer needs.
- it combines the GroupGenerator resolution from each of the instantiated generators.

The JMX collector is now being controlled by the ``ResolverGroupGenerator``, so it is prepared for asynchronous, dynamic resolvers.
The other resolvers already did the right thing.