### PR TITLE
Allow for not linking API server.

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -49,11 +49,6 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.groupon.monsoon</groupId>
-            <artifactId>monsoon-api</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore-nio</artifactId>
             <version>4.4.4</version>


### PR DESCRIPTION
Changes the pipeline builders to use reflection to find the builtin API server.

Pros:
- monsoon utilities code reduced from ~40MB to ~15MB.

Cons:
- to use the default API server, you'll need to explicitly depend on monsoon-api module.
- there is no compile-time check.

Alternative:
- make the API server only include required angular2 code, currently it loads the entire debug environment, which is a bit silly. (Okay, a lot silly.)
