### PR TITLE
Url collector reactor workaround

### DIFF
--- a/collectors/http/src/main/java/com/groupon/lex/metrics/collector/httpget/UrlGetCollector.java
+++ b/collectors/http/src/main/java/com/groupon/lex/metrics/collector/httpget/UrlGetCollector.java
@@ -110,7 +110,8 @@ public class UrlGetCollector implements GroupGenerator {
 
     private static synchronized GCCloseable<CloseableHttpAsyncClient> get_http_client_() {
         GCCloseable<CloseableHttpAsyncClient> result = http_client_.get();
-        if (!result.get().isRunning()) result = null;  // Reactor appears to spontaneously shut down.
+        if (result != null && !result.get().isRunning())
+            result = null;  // Reactor appears to spontaneously shut down.
         if (result == null) {
             result = new GCCloseable<>(HttpAsyncClientBuilder.create()
                     .useSystemProperties()

--- a/collectors/http/src/test/java/com/groupon/lex/metrics/collector/httpget/UrlPatternTest.java
+++ b/collectors/http/src/test/java/com/groupon/lex/metrics/collector/httpget/UrlPatternTest.java
@@ -39,7 +39,6 @@ import com.groupon.lex.metrics.resolver.SimpleBoundNameResolver;
 import com.groupon.lex.metrics.resolver.ConstResolver;
 import com.groupon.lex.metrics.resolver.NameBoundResolverSet;
 import com.groupon.lex.metrics.resolver.ResolverTuple;
-import static com.groupon.lex.metrics.resolver.ResolverTuple.newTupleElement;
 import static java.util.Collections.EMPTY_LIST;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,12 +50,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import com.groupon.lex.metrics.resolver.NameBoundResolver;
-import static com.groupon.lex.metrics.resolver.ResolverTuple.newTupleElement;
-import static com.groupon.lex.metrics.resolver.ResolverTuple.newTupleElement;
-import static com.groupon.lex.metrics.resolver.ResolverTuple.newTupleElement;
-import static com.groupon.lex.metrics.resolver.ResolverTuple.newTupleElement;
-import static com.groupon.lex.metrics.resolver.ResolverTuple.newTupleElement;
-import static com.groupon.lex.metrics.resolver.ResolverTuple.newTupleElement;
 import static com.groupon.lex.metrics.resolver.ResolverTuple.newTupleElement;
 
 /**


### PR DESCRIPTION
apache-nio HTTP client appears to occasionally shut down.  No idea why.
As a work-around, restart the HTTP client if it appears to have stopped.