### PR TITLE
Catch exceptions that may be returned by CollectHistory.add.

### DIFF
--- a/impl/src/main/java/com/groupon/lex/metrics/PushMetricRegistryInstance.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PushMetricRegistryInstance.java
@@ -116,7 +116,11 @@ public class PushMetricRegistryInstance extends MetricRegistryInstance {
             @Override
             public void commit() {
                 alerts_ = unmodifiableMap(alerts);
-                getHistory().ifPresent(history -> history.add(getCollectionData()));
+                try {
+                    getHistory().ifPresent(history -> history.add(getCollectionData()));
+                } catch (Exception ex) {
+                    logger.log(Level.WARNING, "unable to add collection data to history (dropped)", ex);
+                }
             }
         };
     }


### PR DESCRIPTION
Detected a bug when taking down my history server, causing my collection cycle to stop.

It likely also present with the file-based history, I just never have that throw an exception so far.