### PR TITLE
Interpolation

### DIFF
--- a/impl/src/main/java/com/groupon/lex/metrics/PushMetricRegistryInstance.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/PushMetricRegistryInstance.java
@@ -56,16 +56,18 @@ import org.joda.time.DateTime;
  */
 public class PushMetricRegistryInstance extends MetricRegistryInstance {
     private static final Logger logger = Logger.getLogger(PushMetricRegistryInstance.class.getName());
-    private final TimeSeriesCollectionPairInstance data_ = new TimeSeriesCollectionPairInstance();
+    private final TimeSeriesCollectionPairInstance data_;
     private Map<GroupName, Alert> alerts_ = new HashMap<>();
     private Optional<CollectHistory> history_ = Optional.empty();
 
     public PushMetricRegistryInstance(boolean has_config, EndpointRegistration api) {
         super(has_config, api);
+        data_ = new TimeSeriesCollectionPairInstance(super.now());
     }
 
     public PushMetricRegistryInstance(Supplier<DateTime> now, boolean has_config, EndpointRegistration api) {
         super(now, has_config, api);
+        data_ = new TimeSeriesCollectionPairInstance(super.now());
     }
 
     /** Set the history module that the push processor is to use. */

--- a/impl/src/main/java/com/groupon/lex/metrics/history/HistoryContext.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/history/HistoryContext.java
@@ -33,8 +33,8 @@ public class HistoryContext implements Context {
 
         private TSCPair(TSCPair origin, TimeSeriesCollection next, ExpressionLookBack lookback) {
             super(origin);
-            if (origin.current_ != null) update(origin.current_, lookback);
             current_ = next;
+            if (origin.current_ != null) update(origin.current_, lookback, () -> {});
         }
 
         @Override

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/AbstractTSCPair.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/AbstractTSCPair.java
@@ -3,31 +3,33 @@ package com.groupon.lex.metrics.timeseries;
 import com.groupon.lex.metrics.history.CollectHistory;
 import com.groupon.lex.metrics.lib.ForwardIterator;
 import java.util.ArrayList;
-import static java.util.Collections.EMPTY_LIST;
 import static java.util.Collections.unmodifiableList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.joda.time.DateTime;
-import org.joda.time.Duration;
 
 /**
  * A TimeSeriesCollectionPair that keeps track of historical data.
  */
 public abstract class AbstractTSCPair implements TimeSeriesCollectionPair {
     private static final Logger LOG = Logger.getLogger(AbstractTSCPair.class.getName());
-    private List<BackRefTimeSeriesCollection> previous_ = new ArrayList<>();
+    private List<BackRefTimeSeriesCollection> previous_;
 
-    protected AbstractTSCPair() {}
+    protected AbstractTSCPair() {
+        previous_ = new ArrayList<>();
+    }
 
     protected AbstractTSCPair(AbstractTSCPair original) {
-        original.previous_.forEach(previous_::add);
+        previous_ = new ArrayList<>(original.previous_);
     }
+
+    @Override
+    public abstract TimeSeriesCollection getCurrentCollection();
 
     public void initWithHistoricalData(CollectHistory history, ExpressionLookBack lookback) {
         if (!previous_.isEmpty()) {
@@ -55,72 +57,11 @@ public abstract class AbstractTSCPair implements TimeSeriesCollectionPair {
     }
 
     @Override
-    public TimeSeriesCollection getPreviousCollection() {
-        if (previous_.isEmpty()) return new MutableTimeSeriesCollection();
-        return previous_.get(0);
-    }
-
-    @Override
     public Optional<TimeSeriesCollection> getPreviousCollection(int n) {
+        if (n < 0) throw new IllegalArgumentException("cannot look into the future");
         if (n == 0) return Optional.of(getCurrentCollection());
-        if (n == 1) return Optional.of(getPreviousCollection());
         if (n - 1 >= previous_.size()) return Optional.empty();
         return Optional.of(previous_.get(n - 1));
-    }
-
-    @Override
-    public TimeSeriesCollectionPair getPreviousCollectionPair(int n) {
-        if (n < 0) throw new IllegalArgumentException("cannot look into the future");
-        if (n == 0) return this;
-        if (n - 1 >= previous_.size()) return new ImmutableTimeSeriesCollectionPair(EMPTY_LIST);
-        return ImmutableTimeSeriesCollectionPair.copyList(previous_.subList(n - 1, previous_.size()));
-    }
-
-    @Override
-    public Optional<TimeSeriesCollection> getPreviousCollection(Duration duration) {
-        final DateTime ts = getCurrentCollection().getTimestamp().minus(duration);
-        if (!getCurrentCollection().getTimestamp().isAfter(ts)) return Optional.of(getCurrentCollection());
-
-        for (TimeSeriesCollection p : previous_) {
-            if (!p.getTimestamp().isAfter(ts))
-                return Optional.of(p);
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public TimeSeriesCollectionPair getPreviousCollectionPair(Duration duration) {
-        final DateTime ts = getCurrentCollection().getTimestamp().minus(duration);
-        if (!getCurrentCollection().getTimestamp().isAfter(ts)) return this;
-
-        final ListIterator<BackRefTimeSeriesCollection> p = previous_.listIterator(0);
-        while (p.hasNext()) {
-            final int idx = p.nextIndex();
-            final TimeSeriesCollection next = p.next();
-            if (!next.getTimestamp().isAfter(ts))
-                return ImmutableTimeSeriesCollectionPair.copyList(previous_.subList(idx, previous_.size()));
-        }
-        return new ImmutableTimeSeriesCollectionPair(EMPTY_LIST);
-    }
-
-    @Override
-    public List<TimeSeriesCollectionPair> getCollectionPairsSince(Duration duration) {
-        final DateTime ts = getCurrentCollection().getTimestamp().minus(duration);
-
-        int lastIdx;
-        for (final ListIterator<BackRefTimeSeriesCollection> p = previous_.listIterator(0); /* SKIP */; /* SKIP */) {
-            lastIdx = p.nextIndex();
-            if (!p.hasNext() || p.next().getTimestamp().isBefore(ts))
-                break;
-        }
-
-        final List<TimeSeriesCollectionPair> pairs = new ArrayList<>(lastIdx + 1);
-        for (int idx = lastIdx - 1; idx >= 0; --idx)
-            pairs.add(ImmutableTimeSeriesCollectionPair.copyList(previous_.subList(idx, previous_.size())));
-        if (!getCurrentCollection().getTimestamp().isBefore(ts))
-            pairs.add(this);
-
-        return pairs;
     }
 
     protected void update(TimeSeriesCollection tsc, ExpressionLookBack lookback) {
@@ -134,7 +75,7 @@ public abstract class AbstractTSCPair implements TimeSeriesCollectionPair {
                 .sorted(Comparator.comparing(TimeSeriesCollection::getTimestamp).reversed())
                 .collect(Collectors.toList());
 
-        if (suggested_previous.isEmpty())
+        if (suggested_previous.isEmpty())  // Always keep at least 1 element.
             previous_.subList(1, previous_.size()).clear();
         else
             previous_ = suggested_previous;
@@ -146,5 +87,10 @@ public abstract class AbstractTSCPair implements TimeSeriesCollectionPair {
                 .map(TimeSeriesCollection::getTimestamp)
                 .map(DateTime::toString)
                 .collect(Collectors.joining(", ", "AbstractTSCPair[", "]"));
+    }
+
+    @Override
+    public int size() {
+        return previous_.size() + 1;
     }
 }

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/ImmutableTimeSeriesCollectionPair.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/ImmutableTimeSeriesCollectionPair.java
@@ -1,13 +1,9 @@
 package com.groupon.lex.metrics.timeseries;
 
 import java.util.ArrayList;
-import static java.util.Collections.EMPTY_LIST;
 import static java.util.Collections.unmodifiableList;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Optional;
-import org.joda.time.DateTime;
-import org.joda.time.Duration;
 
 /**
  *
@@ -26,69 +22,20 @@ public class ImmutableTimeSeriesCollectionPair implements TimeSeriesCollectionPa
 
     @Override
     public TimeSeriesCollection getCurrentCollection() {
-        if (history_.isEmpty()) return new MutableTimeSeriesCollection();
+        if (history_.isEmpty())
+            return new MutableTimeSeriesCollection();
         return history_.get(0);
     }
 
     @Override
-    public TimeSeriesCollection getPreviousCollection() {
-        if (history_.isEmpty()) return new MutableTimeSeriesCollection();
-        if (history_.size() == 1) return new MutableTimeSeriesCollection(history_.get(0).getTimestamp());
-        return history_.get(1);
-    }
-
-    @Override
     public Optional<TimeSeriesCollection> getPreviousCollection(int n) {
-        if (history_.size() <= n) return Optional.empty();
+        if (n < 0) throw new IllegalArgumentException("cannot look into the future");
+        if (n >= history_.size()) return Optional.empty();
         return Optional.of(history_.get(n));
     }
 
     @Override
-    public Optional<TimeSeriesCollection> getPreviousCollection(Duration duration) {
-        if (history_.isEmpty()) return Optional.empty();
-        final DateTime ts = getCurrentCollection().getTimestamp().minus(duration);
-        final ListIterator<TimeSeriesCollection> iter = history_.listIterator(1);
-        while (iter.hasNext()) {
-            final TimeSeriesCollection next = iter.next();
-            if (!next.getTimestamp().isAfter(ts)) return Optional.of(next);
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public TimeSeriesCollectionPair getPreviousCollectionPair(int n) {
-        if (history_.size() <= n) return new ImmutableTimeSeriesCollectionPair(EMPTY_LIST);
-        return new ImmutableTimeSeriesCollectionPair(history_.subList(n, history_.size()));
-    }
-
-    @Override
-    public TimeSeriesCollectionPair getPreviousCollectionPair(Duration duration) {
-        if (history_.isEmpty()) return new ImmutableTimeSeriesCollectionPair(EMPTY_LIST);
-        final DateTime ts = getCurrentCollection().getTimestamp().minus(duration);
-        final ListIterator<TimeSeriesCollection> iter = history_.listIterator(1);
-        while (iter.hasNext()) {
-            final int iter_idx = iter.nextIndex();
-            final TimeSeriesCollection next = iter.next();
-            if (!next.getTimestamp().isAfter(ts)) return new ImmutableTimeSeriesCollectionPair(history_.subList(iter_idx, history_.size()));
-        }
-        return new ImmutableTimeSeriesCollectionPair(EMPTY_LIST);
-    }
-
-    @Override
-    public List<TimeSeriesCollectionPair> getCollectionPairsSince(Duration duration) {
-        final DateTime ts = getCurrentCollection().getTimestamp().minus(duration);
-
-        int lastIdx;
-        for (final ListIterator<TimeSeriesCollection> p = history_.listIterator(0); /* SKIP */; /* SKIP */) {
-            lastIdx = p.nextIndex();
-            if (!p.hasNext() || p.next().getTimestamp().isBefore(ts))
-                break;
-        }
-
-        final List<TimeSeriesCollectionPair> pairs = new ArrayList<>(lastIdx + 1);
-        for (int idx = lastIdx - 1; idx >= 0; --idx)
-            pairs.add(ImmutableTimeSeriesCollectionPair.copyList(history_.subList(idx, history_.size())));
-
-        return pairs;
+    public int size() {
+        return history_.size();
     }
 }

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/ImmutableTimeSeriesCollectionPair.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/ImmutableTimeSeriesCollectionPair.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import static java.util.Collections.unmodifiableList;
 import java.util.List;
 import java.util.Optional;
+import org.joda.time.DateTime;
 
 /**
  *
@@ -11,9 +12,19 @@ import java.util.Optional;
  */
 public class ImmutableTimeSeriesCollectionPair implements TimeSeriesCollectionPair {
     private final List<TimeSeriesCollection> history_;
+    private final TimeSeriesCollectionPair parent_;  // May be null.
+
+    public ImmutableTimeSeriesCollectionPair(List<? extends TimeSeriesCollection> tsc, Optional<TimeSeriesCollectionPair> parent) {
+        history_ = unmodifiableList(tsc);
+        parent_ = parent.orElse(null);
+    }
 
     public ImmutableTimeSeriesCollectionPair(List<? extends TimeSeriesCollection> tsc) {
-        history_ = unmodifiableList(tsc);
+        this(tsc, Optional.empty());
+    }
+
+    public ImmutableTimeSeriesCollectionPair(List<? extends TimeSeriesCollection> tsc, TimeSeriesCollectionPair parent) {
+        this(tsc, Optional.of(parent));
     }
 
     public static TimeSeriesCollectionPair copyList(List<? extends TimeSeriesCollection> tsc) {
@@ -32,6 +43,12 @@ public class ImmutableTimeSeriesCollectionPair implements TimeSeriesCollectionPa
         if (n < 0) throw new IllegalArgumentException("cannot look into the future");
         if (n >= history_.size()) return Optional.empty();
         return Optional.of(history_.get(n));
+    }
+
+    @Override
+    public TimeSeriesCollection getPreviousCollectionAt(DateTime ts) {
+        if (parent_ != null) return parent_.getPreviousCollectionAt(ts);
+        return TimeSeriesCollectionPair.getPreviousCollectionAt(history_, ts);
     }
 
     @Override

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/ImmutableTimeSeriesCollectionPair.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/ImmutableTimeSeriesCollectionPair.java
@@ -1,6 +1,5 @@
 package com.groupon.lex.metrics.timeseries;
 
-import java.util.ArrayList;
 import static java.util.Collections.unmodifiableList;
 import java.util.List;
 import java.util.Optional;
@@ -25,10 +24,6 @@ public class ImmutableTimeSeriesCollectionPair implements TimeSeriesCollectionPa
 
     public ImmutableTimeSeriesCollectionPair(List<? extends TimeSeriesCollection> tsc, TimeSeriesCollectionPair parent) {
         this(tsc, Optional.of(parent));
-    }
-
-    public static TimeSeriesCollectionPair copyList(List<? extends TimeSeriesCollection> tsc) {
-        return new ImmutableTimeSeriesCollectionPair(new ArrayList<>(tsc));
     }
 
     @Override

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/InterpolatedTSC.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/InterpolatedTSC.java
@@ -278,34 +278,20 @@ public class InterpolatedTSC implements TimeSeriesCollection {
         }
 
         private MetricValue interpolate(MetricValue a, MetricValue b) {
-            {
-                final Optional<Boolean> a_bool = a.asBool();
-                final Optional<Boolean> b_bool = b.asBool();
-                if (a_bool.isPresent() && b_bool.isPresent())
-                    return a;
-            }
+            if (a.getBoolValue() != null && b.getBoolValue() != null)
+                return a;
 
-            {
-                final Optional<Number> a_num = a.value();
-                final Optional<Number> b_num = b.value();
-                if (a_num.isPresent() && b_num.isPresent())
-                    return MetricValue.fromDblValue(backWeight * a_num.get().doubleValue() + forwWeight * b_num.get().doubleValue());
-            }
+            if ((a.getIntValue() != null || a.getFltValue() != null) &&
+                    (b.getIntValue() != null || b.getFltValue() != null))
+                return MetricValue.fromDblValue(backWeight * a.value().get().doubleValue() + forwWeight * b.value().get().doubleValue());
 
-            {
-                Optional<String> a_str = a.asString();
-                Optional<String> b_str = b.asString();
-                if (a_str.isPresent() && b_str.isPresent())
-                    return a;
-            }
+            if (a.getStrValue() != null && b.getStrValue() != null)
+                return a;
 
-            {
-                Optional<Histogram> a_hist = a.histogram();
-                Optional<Histogram> b_hist = b.histogram();
-                if (a_hist.isPresent() && b_hist.isPresent())
-                    return MetricValue.fromHistValue(Histogram.add(
-                            Histogram.multiply(a_hist.get(), backWeight),
-                            Histogram.multiply(b_hist.get(), forwWeight)));
+            if (a.getHistValue() != null && b.getHistValue() != null) {
+                return MetricValue.fromHistValue(Histogram.add(
+                        Histogram.multiply(a.getHistValue(), backWeight),
+                        Histogram.multiply(b.getHistValue(), forwWeight)));
             }
 
             // Mismatched types, return empty metric value.

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/InterpolatedTSC.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/InterpolatedTSC.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics.timeseries;
+
+import com.groupon.lex.metrics.GroupName;
+import com.groupon.lex.metrics.Histogram;
+import com.groupon.lex.metrics.MetricName;
+import com.groupon.lex.metrics.MetricValue;
+import com.groupon.lex.metrics.SimpleGroupPath;
+import com.groupon.lex.metrics.lib.LazyMap;
+import gnu.trove.map.TObjectIntMap;
+import gnu.trove.map.hash.TObjectIntHashMap;
+import gnu.trove.set.hash.THashSet;
+import static java.lang.Math.max;
+import java.util.ArrayList;
+import java.util.Collection;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.Getter;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+
+public class InterpolatedTSC implements TimeSeriesCollection {
+    /** TimeSeriesCollections used for interpolation. */
+    private final List<TimeSeriesCollection> backward, forward;
+    /** Current TimeSeriesCollection. */
+    private final TimeSeriesCollection current;
+    /** TimeSeriesValues. */
+    private final Map<GroupName, TimeSeriesValue> interpolatedTsvMap;
+
+    private final TObjectIntMap<GroupName> backwardNameMap = new TObjectIntHashMap<>(5, 1, -1);
+    private final TObjectIntMap<GroupName> forwardNameMap = new TObjectIntHashMap<>(5, 1, -1);
+
+    public InterpolatedTSC(TimeSeriesCollection current, List<TimeSeriesCollection> backward, List<TimeSeriesCollection> forward) {
+        this.current = current;
+        this.backward = unmodifiableList(new ArrayList<>(backward));
+        this.forward = unmodifiableList(new ArrayList<>(forward));
+        this.interpolatedTsvMap = new LazyMap<>(this::interpolateTSV, calculateNames(this.current, this.backward, this.forward));
+    }
+
+    @Override
+    public TimeSeriesCollection add(TimeSeriesValue tsv) {
+        current.add(tsv);
+        interpolatedTsvMap.remove(tsv.getGroup());
+        return this;
+    }
+
+    @Override
+    public TimeSeriesCollection renameGroup(GroupName oldname, GroupName newname) {
+        final TimeSeriesValue interpolated = interpolatedTsvMap.remove(oldname);
+        if (interpolated != null) {
+            current.add(interpolated);
+        } else {
+            current.renameGroup(oldname, newname);
+            interpolatedTsvMap.remove(newname);
+        }
+        return this;
+    }
+
+    @Override
+    public TimeSeriesCollection addMetrics(GroupName group, Map<MetricName, MetricValue> metrics) {
+        final TimeSeriesValue interpolated = interpolatedTsvMap.remove(group);
+        if (interpolated != null) {
+            metrics = new HashMap<>(metrics);
+            metrics.putAll(interpolated.getMetrics());
+        }
+        current.addMetrics(group, metrics);
+        return this;
+    }
+
+    @Override
+    public DateTime getTimestamp() {
+        return current.getTimestamp();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return interpolatedTsvMap.isEmpty() && current.isEmpty();
+    }
+
+    @Override
+    public Set<GroupName> getGroups() {
+        Set<GroupName> groups =  new HashSet<>(current.getGroups());
+        groups.addAll(interpolatedTsvMap.keySet());
+        return groups;
+    }
+
+    @Override
+    public Set<SimpleGroupPath> getGroupPaths() {
+        return interpolatedTsvMap.keySet().stream()
+                .map(GroupName::getPath)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Collection<TimeSeriesValue> getTSValues() {
+        List<TimeSeriesValue> tsValues = new ArrayList<>(current.getTSValues());
+        tsValues.addAll(interpolatedTsvMap.values());
+        return tsValues;
+    }
+
+    @Override
+    public TimeSeriesValueSet getTSValue(SimpleGroupPath name) {
+        Stream<TimeSeriesValue> interpolatedValues = interpolatedTsvMap.keySet().stream()
+                .filter(g -> g.getPath().equals(name))
+                .map(interpolatedTsvMap::get);
+        Stream<TimeSeriesValue> currentValues = current.getTSValue(name).stream();
+        return new TimeSeriesValueSet(Stream.concat(interpolatedValues, currentValues));
+    }
+
+    @Override
+    public Optional<TimeSeriesValue> get(GroupName name) {
+        final TimeSeriesValue interpolated = interpolatedTsvMap.get(name);
+        if (interpolated != null) return Optional.of(interpolated);
+        return current.get(name);
+    }
+
+    @Override
+    public InterpolatedTSC clone() {
+        return this;  // Immutable.
+    }
+
+    /**
+     * Calculate all names that can be interpolated.
+     * The returned set will not have any names present in the current collection.
+     */
+    private static Set<GroupName> calculateNames(TimeSeriesCollection current, Collection<TimeSeriesCollection> backward, Collection<TimeSeriesCollection> forward) {
+        final Set<GroupName> names = backward.stream()
+                .map(TimeSeriesCollection::getGroups)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toCollection(THashSet::new));
+        names.retainAll(forward.stream()
+                .map(TimeSeriesCollection::getGroups)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet()));
+        names.removeAll(current.getGroups());
+        return names;
+    }
+
+    /**
+     * Interpolates a group name, based on the most recent backward and oldest forward occurence.
+     * @param name The name of the group to interpolate.
+     * @return The interpolated name of the group.
+     */
+    private TimeSeriesValue interpolateTSV(GroupName name) {
+        final TimeSeriesValue
+                backTSV = findName(backward, name, backwardNameMap),
+                forwTSV = findName(forward, name, forwardNameMap);
+
+        final long backMillis = max(new Duration(backTSV.getTimestamp(), getTimestamp()).getMillis(), 0),
+                forwMillis = max(new Duration(getTimestamp(), forwTSV.getTimestamp()).getMillis(), 0);
+        final double totalMillis = forwMillis + backMillis;
+        final double backWeight = forwMillis / totalMillis;
+        final double forwWeight = backMillis / totalMillis;
+
+        return new InterpolatedTSV(getTimestamp(), name, backTSV.getMetrics(), forwTSV.getMetrics(), backWeight, forwWeight);
+    }
+
+    /**
+     * Finds the first resolution of name in the given TimeSeriesCollections.
+     * The cache is used and updated to skip the linear search phase.
+     * @param c TimeSeriesCollection instances in which to search.
+     * @param name The searched for name.  Note that the name must be present in the collection.
+     * @param cache Cache used and updated during lookups, to skip the linear search.
+     * @return The first TimeSeriesValue in the list of TSCollections with the given name.
+     * @throws IllegalStateException if the name was not found.
+     */
+    private static TimeSeriesValue findName(List<TimeSeriesCollection> c, GroupName name, TObjectIntMap<GroupName> cache) {
+        final int cachedIdx = cache.get(name);
+        if (cachedIdx != cache.getNoEntryValue())
+            return c.get(cachedIdx).get(name).orElseThrow(IllegalStateException::new);
+
+        ListIterator<TimeSeriesCollection> iter = c.listIterator();
+        while (iter.hasNext()) {
+            final int idx = iter.nextIndex();
+            final TimeSeriesCollection tsdata = iter.next();
+
+            final Optional<TimeSeriesValue> found = tsdata.get(name);
+            if (found.isPresent()) {
+                cache.put(name, idx);
+                return found.get();
+            }
+        }
+
+        throw new IllegalStateException("name not present in list of time series collections");
+    }
+
+    @Getter
+    private static class InterpolatedTSV implements TimeSeriesValue {
+        private final DateTime timestamp;
+        private final GroupName group;
+        private final Map<MetricName, MetricValue> backward, forward;
+        private final double backWeight, forwWeight;
+        private final Map<MetricName, MetricValue> metrics;
+
+        public InterpolatedTSV(
+                DateTime timestamp,
+                GroupName group,
+                Map<MetricName, MetricValue> backward,
+                Map<MetricName, MetricValue> forward,
+                double backWeight,
+                double forwWeight) {
+            this.timestamp = timestamp;
+            this.group = group;
+            this.backward = backward;
+            this.forward = forward;
+            this.backWeight = backWeight;
+            this.forwWeight = forwWeight;
+
+            // Compute the intersection of metric names.
+            final Set<MetricName> names = new THashSet<>(backward.keySet());
+            names.retainAll(forward.keySet());
+
+            this.metrics = unmodifiableMap(new LazyMap<>(key -> interpolate(backward.get(key), forward.get(key)), names));
+        }
+
+        public InterpolatedTSV clone() {
+            return this;  // Immutable.
+        }
+
+        private MetricValue interpolate(MetricValue a, MetricValue b) {
+            {
+                final Optional<Boolean> a_bool = a.asBool();
+                final Optional<Boolean> b_bool = b.asBool();
+                if (a_bool.isPresent() && b_bool.isPresent())
+                    return a;
+            }
+
+            {
+                final Optional<Number> a_num = a.value();
+                final Optional<Number> b_num = b.value();
+                if (a_num.isPresent() && b_num.isPresent())
+                    return MetricValue.fromDblValue(backWeight * a_num.get().doubleValue() + forwWeight * b_num.get().doubleValue());
+            }
+
+            {
+                Optional<String> a_str = a.asString();
+                Optional<String> b_str = b.asString();
+                if (a_str.isPresent() && b_str.isPresent())
+                    return a;
+            }
+
+            {
+                Optional<Histogram> a_hist = a.histogram();
+                Optional<Histogram> b_hist = b.histogram();
+                if (a_hist.isPresent() && b_hist.isPresent())
+                    return MetricValue.fromHistValue(Histogram.add(
+                            Histogram.multiply(a_hist.get(), backWeight),
+                            Histogram.multiply(b_hist.get(), forwWeight)));
+            }
+
+            // Mismatched types, return empty metric value.
+            return MetricValue.EMPTY;
+        }
+    }
+}

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/InterpolatedTSC.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/InterpolatedTSC.java
@@ -273,6 +273,7 @@ public class InterpolatedTSC implements TimeSeriesCollection {
             this.metrics = unmodifiableMap(new LazyMap<>(key -> interpolate(backward.get(key), forward.get(key)), names));
         }
 
+        @Override
         public InterpolatedTSV clone() {
             return this;  // Immutable.
         }

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/InterpolatedTSC.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/InterpolatedTSC.java
@@ -74,6 +74,27 @@ public class InterpolatedTSC implements TimeSeriesCollection {
         this.backward = unmodifiableList(new ArrayList<>(backward));
         this.forward = unmodifiableList(new ArrayList<>(forward));
         this.interpolatedTsvMap = new LazyMap<>(this::interpolateTSV, calculateNames(this.current, this.backward, this.forward));
+
+        validate();
+    }
+
+    /** Check the forward and backward invariants. */
+    private void validate() {
+        DateTime ts;
+
+        ts = current.getTimestamp();
+        for (TimeSeriesCollection b : backward) {
+            if (b.getTimestamp().isAfter(ts))
+                throw new IllegalArgumentException("backwards collection must be before current and be ordered in reverse chronological order");
+            ts = b.getTimestamp();
+        }
+
+        ts = current.getTimestamp();
+        for (TimeSeriesCollection f : forward) {
+            if (f.getTimestamp().isBefore(ts))
+                throw new IllegalArgumentException("forwards collection must be after current and be ordered in chronological order");
+            ts = f.getTimestamp();
+        }
     }
 
     @Override

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollectionPair.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollectionPair.java
@@ -53,7 +53,7 @@ public interface TimeSeriesCollectionPair {
 
     public default TimeSeriesCollection getPreviousCollection() {
         return getPreviousCollection(1)
-                .orElseGet(MutableTimeSeriesCollection::new);
+                .orElseGet(() -> new MutableTimeSeriesCollection(getCurrentCollection().getTimestamp()));
     }
 
     public Optional<TimeSeriesCollection> getPreviousCollection(int n);

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollectionPair.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollectionPair.java
@@ -33,8 +33,11 @@ package com.groupon.lex.metrics.timeseries;
 
 import com.groupon.lex.metrics.GroupName;
 import com.groupon.lex.metrics.SimpleGroupPath;
+import java.util.ArrayList;
+import static java.util.Collections.EMPTY_LIST;
 import java.util.List;
 import java.util.Optional;
+import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
 /**
@@ -42,14 +45,75 @@ import org.joda.time.Duration;
  * @author ariane
  */
 public interface TimeSeriesCollectionPair {
-    public TimeSeriesCollection getCurrentCollection();
-    public TimeSeriesCollection getPreviousCollection();
+    public default TimeSeriesCollection getCurrentCollection() {
+        return getPreviousCollection(0)
+                .orElseThrow(() -> new IllegalStateException("current collection may never be null"));
+    }
+
+    public default TimeSeriesCollection getPreviousCollection() {
+        return getPreviousCollection(1)
+                .orElseGet(MutableTimeSeriesCollection::new);
+    }
 
     public Optional<TimeSeriesCollection> getPreviousCollection(int n);
-    public Optional<TimeSeriesCollection> getPreviousCollection(Duration duration);
-    public TimeSeriesCollectionPair getPreviousCollectionPair(int n);
-    public TimeSeriesCollectionPair getPreviousCollectionPair(Duration duration);
-    public List<TimeSeriesCollectionPair> getCollectionPairsSince(Duration duration);
+
+    public default Optional<TimeSeriesCollection> getPreviousCollection(Duration duration) {
+        final DateTime ts = getCurrentCollection().getTimestamp().minus(duration);
+
+        for (int i = 0; i < size(); ++i) {
+            final TimeSeriesCollection collection = getPreviousCollection(i).orElseThrow(() -> new IllegalStateException("Collections within range 0..size() must exist"));
+            if (!collection.getTimestamp().isAfter(ts))
+                return Optional.of(collection);
+        }
+        return Optional.empty();
+    }
+
+    public default TimeSeriesCollectionPair getPreviousCollectionPair(int n) {
+        if (n < 0) throw new IllegalArgumentException("cannot look into the future");
+        if (n == 0) return this;
+        if (n >= size()) return new ImmutableTimeSeriesCollectionPair(EMPTY_LIST);
+
+        List<TimeSeriesCollection> tail = new ArrayList<>(size() - n);
+        for (int i = n; i < size(); ++i)
+            tail.add(getPreviousCollection(i).orElseThrow(() -> new IllegalStateException("Collections within range 0..size() must exist")));
+        return ImmutableTimeSeriesCollectionPair.copyList(tail);
+    }
+
+    public default TimeSeriesCollectionPair getPreviousCollectionPair(Duration duration) {
+        final DateTime ts = getCurrentCollection().getTimestamp().minus(duration);
+        if (!getCurrentCollection().getTimestamp().isAfter(ts)) return this;
+
+        List<TimeSeriesCollection> tail = new ArrayList<>();
+        int i;
+        for (i = 1; i < size(); ++i) {
+            final TimeSeriesCollection collection = getPreviousCollection(i).orElseThrow(() -> new IllegalStateException("Collections within range 0..size() must exist"));
+            if (!collection.getTimestamp().isAfter(ts)) {
+                tail.add(collection);
+                ++i;
+                break;
+            }
+        }
+
+        for (int k = i; k < size(); ++k)
+            tail.add(getPreviousCollection(k).orElseThrow(() -> new IllegalStateException("Collections within range 0..size() must exist")));
+        return new ImmutableTimeSeriesCollectionPair(tail);
+    }
+
+    public default List<TimeSeriesCollectionPair> getCollectionPairsSince(Duration duration) {
+        final DateTime ts = getCurrentCollection().getTimestamp().minus(duration);
+
+        int lastIdx;
+        for (lastIdx = 0; lastIdx < size(); ++lastIdx) {
+            final TimeSeriesCollection collection = getPreviousCollection(lastIdx).orElseThrow(() -> new IllegalStateException("Collections within range 0..size() must exist"));
+            if (collection.getTimestamp().isBefore(ts))
+                break;
+        }
+
+        List<TimeSeriesCollectionPair> pairs = new ArrayList<>(lastIdx);
+        for (int idx = lastIdx - 1; idx >= 0; --idx)
+            pairs.add(getPreviousCollectionPair(idx));
+        return pairs;
+    }
 
     public default Duration getCollectionInterval() {
         return new Duration(getPreviousCollection().getTimestamp(), getCurrentCollection().getTimestamp());
@@ -62,4 +126,6 @@ public interface TimeSeriesCollectionPair {
     public default Optional<TimeSeriesValueSet> getTSDeltaByName(GroupName name) {
         return getCurrentCollection().getTSDeltaByName(name);
     }
+
+    public int size();
 }

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollectionPairInstance.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollectionPairInstance.java
@@ -40,10 +40,6 @@ import org.joda.time.DateTime;
 public class TimeSeriesCollectionPairInstance extends AbstractTSCPair {
     private final MutableTimeSeriesCollection current_;
 
-    public TimeSeriesCollectionPairInstance() {
-        current_ = new MutableTimeSeriesCollection();
-    }
-
     public TimeSeriesCollectionPairInstance(DateTime now) {
         current_ = new MutableTimeSeriesCollection(now);
     }
@@ -54,8 +50,7 @@ public class TimeSeriesCollectionPairInstance extends AbstractTSCPair {
     }
 
     public TimeSeriesCollectionPairInstance startNewCycle(DateTime timestamp, ExpressionLookBack lookback) {
-        update(current_, lookback);
-        current_.clear(timestamp);
+        update(current_, lookback, () -> current_.clear(timestamp));
         return this;
     }
 

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/expression/RateExpression.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/expression/RateExpression.java
@@ -117,7 +117,7 @@ public class RateExpression implements TimeSeriesMetricExpression {
     @Override
     public TimeSeriesMetricDeltaSet apply(Context ctx) {
         final Context previous = new PreviousContextWrapper(ctx, interval_
-                .map(intv -> ctx.getTSData().getPreviousCollectionPair(intv))
+                .map(intv -> ctx.getTSData().getPreviousCollectionPairAt(intv))
                 .orElseGet(() -> ctx.getTSData().getPreviousCollectionPair(1)));
         final Duration collection_interval = new Duration(
                 previous.getTSData().getCurrentCollection().getTimestamp(),

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/expression/RateExpression.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/expression/RateExpression.java
@@ -116,9 +116,9 @@ public class RateExpression implements TimeSeriesMetricExpression {
 
     @Override
     public TimeSeriesMetricDeltaSet apply(Context ctx) {
-        final Context previous = new PreviousContextWrapper(ctx, interval_
-                .map(intv -> ctx.getTSData().getPreviousCollectionPairAt(intv))
-                .orElseGet(() -> ctx.getTSData().getPreviousCollectionPair(1)));
+        final Context previous = new PreviousContextWrapper(
+                ctx,
+                ctx.getTSData().getPreviousCollectionPairAt(interval_.orElseGet(() -> ctx.getTSData().getCollectionInterval())));
         final Duration collection_interval = new Duration(
                 previous.getTSData().getCurrentCollection().getTimestamp(),
                 ctx.getTSData().getCurrentCollection().getTimestamp());

--- a/impl/src/test/java/com/groupon/lex/metrics/config/impl/MatchTransformerImplTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/config/impl/MatchTransformerImplTest.java
@@ -60,6 +60,8 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
@@ -127,7 +129,7 @@ public class MatchTransformerImplTest {
         when(group2.getMetrics()).thenReturn(singletonMap(METRIC, MetricValue.EMPTY));
         when(group3.getMetrics()).thenReturn(singletonMap(METRIC, MetricValue.EMPTY));
 
-        final TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance();
+        final TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance(new DateTime(DateTimeZone.UTC));
         ((MutableTimeSeriesCollection)ts_data.getCurrentCollection()).add(group1);
         ((MutableTimeSeriesCollection)ts_data.getCurrentCollection()).add(group2);
         ((MutableTimeSeriesCollection)ts_data.getCurrentCollection()).add(group3);

--- a/impl/src/test/java/com/groupon/lex/metrics/config/parser/FunctionTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/config/parser/FunctionTest.java
@@ -93,7 +93,21 @@ public class FunctionTest extends AbstractAlertTest {
                 + "rate[2m](" + TESTGROUP.configString() + " a) > 1.01*1/60;", 60,
                 newDatapoint(TESTGROUP, "a",            0, 1, 2, null, 4, 5, 6))) {
             impl.validate(newDatapoint(GroupName.valueOf("test"),
-                    UNKNOWN, UNKNOWN, OK, UNKNOWN, OK, UNKNOWN, OK));
+                    UNKNOWN, UNKNOWN, OK, UNKNOWN, OK, OK, OK));
+        }
+    }
+
+    @Test
+    public void rate_duration_inexact() throws Exception {
+        /*
+         * We're comparing for rate between upper and lower bounds, since doubles are really hard to compare for equality.
+         */
+        try (AbstractAlertTest.AlertValidator impl = replay("alert test if "
+                + "rate[1m 30s](" + TESTGROUP.configString() + " a) < 0.99*1/60 ||"
+                + "rate[1m 30s](" + TESTGROUP.configString() + " a) > 1.01*1/60;", 60,
+                newDatapoint(TESTGROUP, "a",            0, 1, 2, null, 4, 5, 6))) {
+            impl.validate(newDatapoint(GroupName.valueOf("test"),
+                    UNKNOWN, UNKNOWN, OK, UNKNOWN, OK, OK, OK));
         }
     }
 
@@ -108,7 +122,7 @@ public class FunctionTest extends AbstractAlertTest {
                 + "rate(" + TESTGROUP.configString() + " a, 2m) > 1.01*1/60;", 60,
                 newDatapoint(TESTGROUP, "a",            0, 1, 2, null, 4, 5, 6))) {
             impl.validate(newDatapoint(GroupName.valueOf("test"),
-                    UNKNOWN, UNKNOWN, OK, UNKNOWN, OK, UNKNOWN, OK));
+                    UNKNOWN, UNKNOWN, OK, UNKNOWN, OK, OK, OK));
         }
     }
 

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/AbstractTSCPairTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/AbstractTSCPairTest.java
@@ -20,7 +20,11 @@ public class AbstractTSCPairTest {
     private static final Logger LOG = Logger.getLogger(AbstractTSCPairTest.class.getName());
 
     private static class Impl extends AbstractTSCPair {
-        public TimeSeriesCollection current = new MutableTimeSeriesCollection();
+        public TimeSeriesCollection current;
+
+        public Impl(DateTime now) {
+            current = new MutableTimeSeriesCollection(now);
+        }
 
         @Override
         public TimeSeriesCollection getCurrentCollection() {
@@ -37,9 +41,9 @@ public class AbstractTSCPairTest {
     private List<MutableTimeSeriesCollection> input;
 
     private void setup(ExpressionLookBack lookback) {
-        impl = new Impl();
-
         now = new DateTime(DateTimeZone.UTC);
+        impl = new Impl(now);
+
         LOG.log(Level.INFO, "now = {0}", now);
         input = unmodifiableList(Stream.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
                 .map(Duration::standardMinutes)
@@ -51,7 +55,7 @@ public class AbstractTSCPairTest {
         Stream.of(10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
                 .map(input::get)
                 .peek(tsc -> LOG.log(Level.INFO, "impl.update({0})", tsc))
-                .forEach(tsc -> impl.update(tsc, lookback));
+                .forEach(tsc -> impl.update(tsc, lookback, () -> {}));
         LOG.log(Level.INFO, "impl = {0}", impl.debugString());
     }
 

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/AbstractTSCPairTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/AbstractTSCPairTest.java
@@ -223,4 +223,20 @@ public class AbstractTSCPairTest {
         assertNotNull(impl.getPreviousCollectionPair(Duration.standardDays(1)));
         assertEquals(Optional.empty(), impl.getPreviousCollection(Duration.standardDays(1)));
     }
+
+    @Test
+    public void previousAt_exact() {
+        final Duration delta2 = Duration.standardMinutes(2);
+        setup(ExpressionLookBack.fromScrapeCount(10));
+
+        assertEquals(input.get(2).getTimestamp(), impl.getPreviousCollectionAt(delta2).getTimestamp());
+    }
+
+    @Test
+    public void previousAt_inexact() {
+        final Duration delta2 = Duration.standardMinutes(2).plus(Duration.standardSeconds(30));
+        setup(ExpressionLookBack.fromScrapeCount(10));
+
+        assertEquals(input.get(0).getTimestamp().minus(delta2), impl.getPreviousCollectionAt(delta2).getTimestamp());
+    }
 }

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollectionPairInstanceTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollectionPairInstanceTest.java
@@ -44,7 +44,6 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
@@ -78,17 +77,14 @@ public class TimeSeriesCollectionPairInstanceTest {
 
     @Test
     public void constructor() {
-        DateTime before = DateTime.now(DateTimeZone.UTC);
-        TimeSeriesCollectionPair ts_data = new TimeSeriesCollectionPairInstance();
-        DateTime after = DateTime.now(DateTimeZone.UTC);
+        DateTime now = DateTime.now(DateTimeZone.UTC);
+        TimeSeriesCollectionPair ts_data = new TimeSeriesCollectionPairInstance(now);
 
         assertNotNull(ts_data.getPreviousCollection());
         assertNotNull(ts_data.getCurrentCollection());
 
-        assertFalse("before <= ts_data.previousCollection().getTimestamp()",
-                before.isAfter(ts_data.getPreviousCollection().getTimestamp()));
-        assertFalse("ts_data.currentCollection().getTimestamp() <= after",
-                ts_data.getCurrentCollection().getTimestamp().isAfter(after));
+        assertEquals(now, ts_data.getPreviousCollection().getTimestamp());
+        assertEquals(now, ts_data.getCurrentCollection().getTimestamp());
         assertNotSame(ts_data.getPreviousCollection(), ts_data.getCurrentCollection());
 
         assertTrue(ts_data.getCurrentCollection().isEmpty());
@@ -97,7 +93,7 @@ public class TimeSeriesCollectionPairInstanceTest {
 
     @Test
     public void constructor_args() {
-        TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance();
+        TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance(date2);
         ts_data.startNewCycle(collection1.getTimestamp(), ExpressionLookBack.EMPTY);
         collection1.getData().values().forEach(ts_data.getCurrentCollection()::add);
         ts_data.startNewCycle(collection0.getTimestamp(), ExpressionLookBack.EMPTY);
@@ -110,7 +106,7 @@ public class TimeSeriesCollectionPairInstanceTest {
 
     @Test
     public void lookup() {
-        TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance();
+        TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance(date2);
         ts_data.startNewCycle(collection1.getTimestamp(), ExpressionLookBack.EMPTY);
         collection1.getData().values().forEach(ts_data.getCurrentCollection()::add);
         ts_data.startNewCycle(collection0.getTimestamp(), ExpressionLookBack.EMPTY);
@@ -122,7 +118,7 @@ public class TimeSeriesCollectionPairInstanceTest {
 
     @Test
     public void lookup_current_only() {
-        TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance();
+        TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance(date2);
         ts_data.startNewCycle(collection1.getTimestamp(), ExpressionLookBack.EMPTY);
         collection1.getData().values().forEach(ts_data.getCurrentCollection()::add);
         ts_data.startNewCycle(collection0.getTimestamp(), ExpressionLookBack.EMPTY);
@@ -134,7 +130,7 @@ public class TimeSeriesCollectionPairInstanceTest {
 
     @Test
     public void lookup_past_only() {
-        TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance();
+        TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance(date2);
         ts_data.startNewCycle(collection1.getTimestamp(), ExpressionLookBack.EMPTY);
         collection1.getData().values().forEach(ts_data.getCurrentCollection()::add);
         ts_data.startNewCycle(collection0.getTimestamp(), ExpressionLookBack.EMPTY);
@@ -146,7 +142,7 @@ public class TimeSeriesCollectionPairInstanceTest {
 
     @Test
     public void lookup_non_existent() {
-        TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance();
+        TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance(date2);
         ts_data.startNewCycle(collection1.getTimestamp(), ExpressionLookBack.EMPTY);
         collection1.getData().values().forEach(ts_data.getCurrentCollection()::add);
         ts_data.startNewCycle(collection0.getTimestamp(), ExpressionLookBack.EMPTY);

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/ArithmaticFloatTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/ArithmaticFloatTest.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -38,6 +38,8 @@ import com.groupon.lex.metrics.timeseries.TimeSeriesMetricDeltaSet;
 import static com.groupon.lex.metrics.timeseries.expression.Checks.testResult;
 import static com.groupon.lex.metrics.timeseries.expression.Util.constantExpression;
 import static java.lang.Math.scalb;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,7 +52,7 @@ public class ArithmaticFloatTest {
 
     @Before
     public void setup() {
-        ctx = new SimpleContext(new TimeSeriesCollectionPairInstance(), (Alert alert) -> {});
+        ctx = new SimpleContext(new TimeSeriesCollectionPairInstance(DateTime.now(DateTimeZone.UTC)), (Alert alert) -> {});
     }
 
     @Test

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/ArithmaticIntegralTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/ArithmaticIntegralTest.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -38,6 +38,8 @@ import com.groupon.lex.metrics.timeseries.TimeSeriesMetricDeltaSet;
 import static com.groupon.lex.metrics.timeseries.expression.Checks.testCoercion;
 import static com.groupon.lex.metrics.timeseries.expression.Checks.testResult;
 import static com.groupon.lex.metrics.timeseries.expression.Util.constantExpression;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,7 +52,7 @@ public class ArithmaticIntegralTest {
 
     @Before
     public void setup() {
-        ctx = new SimpleContext(new TimeSeriesCollectionPairInstance(), (Alert alert) -> {});
+        ctx = new SimpleContext(new TimeSeriesCollectionPairInstance(DateTime.now(DateTimeZone.UTC)), (Alert alert) -> {});
     }
 
     @Test

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/BooleanExprTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/BooleanExprTest.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -40,6 +40,8 @@ import static com.groupon.lex.metrics.timeseries.expression.Checks.testCoercion;
 import static com.groupon.lex.metrics.timeseries.expression.Checks.testResult;
 import static com.groupon.lex.metrics.timeseries.expression.Checks.testResultEmpty;
 import static com.groupon.lex.metrics.timeseries.expression.Util.constantExpression;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,7 +54,7 @@ public class BooleanExprTest {
 
     @Before
     public void setup() {
-        ctx = new SimpleContext(new TimeSeriesCollectionPairInstance(), (Alert alert) -> {});
+        ctx = new SimpleContext(new TimeSeriesCollectionPairInstance(DateTime.now(DateTimeZone.UTC)), (Alert alert) -> {});
     }
 
     @Test

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/MetricSelectorTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/MetricSelectorTest.java
@@ -69,7 +69,7 @@ public class MetricSelectorTest {
     public void setup() {
         final MutableTimeSeriesCollection previous = new MutableTimeSeriesCollection(t0.minus(Duration.standardMinutes(1)));
         final MutableTimeSeriesCollection current = new MutableTimeSeriesCollection(t0, Stream.of(new MutableTimeSeriesValue(t0, GroupName.valueOf("99", "Luftballons"), singletonMap(MetricName.valueOf("value"), MetricValue.fromIntValue(17)))));
-        final TimeSeriesCollectionPair ts_data = new TimeSeriesCollectionPairInstance() {{
+        final TimeSeriesCollectionPair ts_data = new TimeSeriesCollectionPairInstance(t0.minus(Duration.standardMinutes(2))) {{
             startNewCycle(previous.getTimestamp(), ExpressionLookBack.EMPTY);
             previous.getData().values().forEach(this.getCurrentCollection()::add);
             startNewCycle(current.getTimestamp(), ExpressionLookBack.EMPTY);

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/MutableContextTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/MutableContextTest.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -37,6 +37,8 @@ import com.groupon.lex.metrics.timeseries.TimeSeriesCollectionPairInstance;
 import java.util.Optional;
 import java.util.function.Consumer;
 import static org.hamcrest.Matchers.hasKey;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -48,7 +50,7 @@ import org.junit.Test;
  * @author ariane
  */
 public class MutableContextTest {
-    private final TimeSeriesCollectionPair ts_data = new TimeSeriesCollectionPairInstance();
+    private final TimeSeriesCollectionPair ts_data = new TimeSeriesCollectionPairInstance(DateTime.now(DateTimeZone.UTC));
     private final Consumer<Alert> alert_manager = (Alert alert) -> {};
     private final String DATA = "The quick brown fox...";
     private final String ALIAS = "alias";
@@ -77,7 +79,7 @@ public class MutableContextTest {
     @Test
     public void construct_from_copy_with_tsdata() {
         Context parent = new SimpleContext(ts_data, alert_manager);
-        TimeSeriesCollectionPair new_tsdata = new TimeSeriesCollectionPairInstance();
+        TimeSeriesCollectionPair new_tsdata = new TimeSeriesCollectionPairInstance(DateTime.now(DateTimeZone.UTC));
         MutableContext ctx = new MutableContext(new_tsdata, parent);
 
         assertSame(alert_manager, ctx.getAlertManager());

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/SimpleContextTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/SimpleContextTest.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -36,6 +36,8 @@ import com.groupon.lex.metrics.timeseries.TimeSeriesCollectionPair;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollectionPairInstance;
 import java.util.Optional;
 import java.util.function.Consumer;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -46,7 +48,7 @@ import org.junit.Test;
  * @author ariane
  */
 public class SimpleContextTest {
-    private final TimeSeriesCollectionPair ts_data = new TimeSeriesCollectionPairInstance();
+    private final TimeSeriesCollectionPair ts_data = new TimeSeriesCollectionPairInstance(DateTime.now(DateTimeZone.UTC));
     private final Consumer<Alert> alert_manager = (Alert alert) -> {};
 
     @Test

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/StringExprTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/StringExprTest.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -36,6 +36,8 @@ import com.groupon.lex.metrics.timeseries.TagMatchingClause;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollectionPairInstance;
 import static com.groupon.lex.metrics.timeseries.expression.Checks.testResult;
 import static com.groupon.lex.metrics.timeseries.expression.Util.constantExpression;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,7 +50,7 @@ public class StringExprTest {
 
     @Before
     public void setup() {
-        ctx = new SimpleContext(new TimeSeriesCollectionPairInstance(), (Alert alert) -> {});
+        ctx = new SimpleContext(new TimeSeriesCollectionPairInstance(DateTime.now(DateTimeZone.UTC)), (Alert alert) -> {});
     }
 
     @Test

--- a/impl/src/test/java/com/groupon/lex/metrics/transformers/IdentifierNameResolverTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/transformers/IdentifierNameResolverTest.java
@@ -12,6 +12,8 @@ import com.groupon.lex.metrics.transformers.IdentifierNameResolver.SubSelectInde
 import com.groupon.lex.metrics.transformers.IdentifierNameResolver.SubSelectRange;
 import static java.util.Collections.EMPTY_MAP;
 import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +31,7 @@ public class IdentifierNameResolverTest {
     @Before
     public void setup() {
         final GroupName group_name = GroupName.valueOf(group_path);
-        final TimeSeriesCollectionPair ts_data = new TimeSeriesCollectionPairInstance();
+        final TimeSeriesCollectionPair ts_data = new TimeSeriesCollectionPairInstance(DateTime.now(DateTimeZone.UTC));
         tsv0 = new MutableTimeSeriesValue(ts_data.getCurrentCollection().getTimestamp(), group_name, EMPTY_MAP);
         ts_data.getCurrentCollection().add(tsv0);
 

--- a/impl/src/test/java/com/groupon/lex/metrics/transformers/NameResolverCombineTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/transformers/NameResolverCombineTest.java
@@ -35,6 +35,8 @@ import com.groupon.lex.metrics.SimpleGroupPath;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollectionPairInstance;
 import com.groupon.lex.metrics.timeseries.expression.SimpleContext;
 import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -70,7 +72,7 @@ public class NameResolverCombineTest {
 
     @Test
     public void resolve() {
-        Optional<SimpleGroupPath> path = resolver.apply(new SimpleContext(new TimeSeriesCollectionPairInstance(), (alert) -> {})).map(p -> SimpleGroupPath.valueOf(p.getPath()));
+        Optional<SimpleGroupPath> path = resolver.apply(new SimpleContext(new TimeSeriesCollectionPairInstance(DateTime.now(DateTimeZone.UTC)), (alert) -> {})).map(p -> SimpleGroupPath.valueOf(p.getPath()));
 
         assertEquals(Optional.of(SimpleGroupPath.valueOf("x", "y")), path);
     }

--- a/lib/src/main/java/com/groupon/lex/metrics/lib/LazyMap.java
+++ b/lib/src/main/java/com/groupon/lex/metrics/lib/LazyMap.java
@@ -1,0 +1,495 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics.lib;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import static java.util.Collections.singleton;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+/**
+ * A map that lazily computes its mapped values.
+ */
+public class LazyMap<K, V> implements Map<K, V> {
+    private static final Object SENTINEL = new Object();
+    private final Function<? super K, ? extends V> compute;
+    private final Map<K, V> internalMap;
+
+    public LazyMap(Function<? super K, ? extends V> compute) {
+        this(compute, HashMap<K, V>::new);
+    }
+
+    public LazyMap(Function<? super K, ? extends V> compute, Supplier<Map<K, V>> mapSupplier) {
+        this.compute = compute;
+        this.internalMap = mapSupplier.get();
+    }
+
+    public LazyMap(Function<? super K, ? extends V> compute, Collection<? extends K> initialKeys) {
+        this(compute, initialKeys, HashMap<K, V>::new);
+    }
+
+    public LazyMap(Function<? super K, ? extends V> compute, Collection<? extends K> initialKeys, Supplier<Map<K, V>> mapSupplier) {
+        this(compute, mapSupplier);
+        initialKeys.forEach(k -> internalMap.put(k, getSentinel()));
+    }
+
+    @Override
+    public boolean isEmpty() { return internalMap.isEmpty(); }
+    @Override
+    public int size() { return internalMap.size(); }
+
+    @Override
+    public V get(Object key) {
+        V v = internalMap.get(key);
+        if (v == SENTINEL) {
+            v = compute.apply((K)key);
+            internalMap.put((K)key, v);
+        }
+        return v;
+    }
+
+    @Override
+    public V put(K key, V value) {
+        V v = internalMap.put(key, value);
+        if (v == SENTINEL)
+            v = compute.apply(key);
+        return v;
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        internalMap.putAll(m);
+    }
+
+    @Override
+    public V remove(Object k) {
+        V v = internalMap.remove(k);
+        if (v == SENTINEL)
+            v = compute.apply((K)k);
+        return v;
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return internalMap.keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return new ValuesCollection();
+    }
+
+    @Override
+    public Set<Map.Entry<K, V>> entrySet() {
+        return new EntrySet();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return internalMap.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        List<Map.Entry<K, V>> sentinelValues = new ArrayList<>();
+
+        for (Map.Entry<K, V> e : entrySet()) {
+            if (internalMap.get(e.getKey()) == SENTINEL)
+                sentinelValues.add(e);
+            else if (Objects.equals(e.getValue(), value))
+                return true;
+        }
+
+        for (Map.Entry<K, V> e : sentinelValues) {
+            if (Objects.equals(e.getValue(), value))
+                return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public void clear() {
+        internalMap.clear();
+    }
+
+    @Override
+    public int hashCode() {
+        return entrySet().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        if (!(o instanceof Map)) return false;
+        Map m = (Map)o;
+
+        return entrySet().equals(m.entrySet());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getSentinel() {
+        return (T)SENTINEL;
+    }
+
+    @RequiredArgsConstructor
+    private class EntrySetIterator implements Iterator<Map.Entry<K, V>> {
+        private final Iterator<K> internalIter;
+
+        @Override
+        public boolean hasNext() { return internalIter.hasNext(); }
+        @Override
+        public Map.Entry<K, V> next() { return new LazyMapEntry(internalIter.next()); }
+        @Override
+        public void remove() { internalIter.remove(); }
+    }
+
+    @RequiredArgsConstructor
+    @ToString
+    @Getter
+    private class LazyMapEntry implements Map.Entry<K, V> {
+        private final K key;
+
+        @Override
+        public V getValue() { return LazyMap.this.get(key); }
+        @Override
+        public V setValue(V v) { return LazyMap.this.put(key, v); }
+
+        @Override
+        public int hashCode() {
+            return (getKey() == null   ? 0 : getKey().hashCode()) ^
+                    (getValue() == null ? 0 : getValue().hashCode());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null) return false;
+            if (!(o instanceof Map.Entry)) return false;
+
+            final Map.Entry<?, ?> other = (Map.Entry<?, ?>)o;
+            return Objects.equals(getKey(), other.getKey()) && Objects.equals(getValue(), other.getValue());
+        }
+    }
+
+    private class EntrySet implements Set<Map.Entry<K, V>> {
+        @Override
+        public Iterator<Map.Entry<K, V>> iterator() {
+            return new EntrySetIterator(internalMap.keySet().iterator());
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends Map.Entry<K, V>> c) {
+            boolean changed = false;
+
+            for (Map.Entry<K, V> e : c) {
+                K k = e.getKey();
+
+                V v = LazyMap.this.get(k);
+                final boolean present = !(v == null && !internalMap.containsKey(k));
+                if (present && Objects.equals(e.getValue(), v))
+                    continue;
+
+                internalMap.put(k, e.getValue());
+                changed = true;
+            }
+            return changed;
+        }
+
+        @Override
+        public boolean containsAll(Collection<?> c) {
+            for (Object eObj : c) {
+                if (eObj == null || !(eObj instanceof Map.Entry)) return false;
+                Map.Entry e = (Map.Entry)eObj;
+                Object k = e.getKey();
+
+                V v = LazyMap.this.get((K)k);
+                if (v == null && !internalMap.containsKey((K)k))
+                    return false;
+                if (!Objects.equals(e.getValue(), v))
+                    return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public boolean removeAll(Collection<?> c) {
+            boolean changed = false;
+
+            for (Object eObj : c) {
+                if (eObj == null || !(eObj instanceof Map.Entry)) continue;
+                Map.Entry e = (Map.Entry)eObj;
+                Object k = e.getKey();
+
+                V v = LazyMap.this.get(k);
+                if (Objects.equals(e.getValue(), v)) {
+                    if (LazyMap.this.remove(k, v))
+                        changed = true;
+                }
+            }
+            return changed;
+        }
+
+        @Override
+        public boolean retainAll(Collection<?> c) {
+            boolean changed = false;
+
+            for (Object eObj : c) {
+                if (eObj == null || !(eObj instanceof Map.Entry)) continue;
+                Map.Entry e = (Map.Entry)eObj;
+                Object k = e.getKey();
+
+                V v = LazyMap.this.get(k);
+                if (!Objects.equals(e.getValue(), v)) {
+                    if (LazyMap.this.remove(k, v))
+                        changed = true;
+                }
+            }
+            return changed;
+        }
+
+        @Override
+        public boolean add(Map.Entry<K, V> e) { return addAll(singleton(e)); }
+        @Override
+        public boolean contains(Object e) { return containsAll(singleton(e)); }
+        @Override
+        public boolean remove(Object o) { return removeAll(singleton(o)); }
+        @Override
+        public void clear() { LazyMap.this.clear(); }
+        @Override
+        public int size() { return LazyMap.this.size(); }
+        @Override
+        public boolean isEmpty() { return LazyMap.this.isEmpty(); }
+
+        @Override
+        public Object[] toArray() {
+            final Object[] result = new Object[size()];
+            Iterator<Entry<K, V>> iter = iterator();
+            for (int idx = 0; iter.hasNext(); ++idx) {
+                result[idx] = iter.next();
+            }
+            return result;
+        }
+
+        @Override
+        public <T> T[] toArray(T[] a) {
+            if (a.length < size())
+                a = Arrays.copyOf(a, size());
+
+            Iterator<Entry<K, V>> iter = iterator();
+            for (int idx = 0; iter.hasNext(); ++idx) {
+                a[idx] = (T)iter.next();
+            }
+            return a;
+        }
+
+        @Override
+        public int hashCode() {
+            int sumOfHashcodes = 0;
+            final Iterator<Entry<K, V>> i = iterator();
+            while (i.hasNext()) {
+                sumOfHashcodes += i.next().hashCode();
+            }
+            return sumOfHashcodes;
+        }
+
+        @Override
+        public boolean equals(Object otherObj) {
+            if (otherObj == null) return false;
+            if (!(otherObj instanceof Set)) return false;
+
+            final List<Map.Entry<K, V>> sentinelValues = new ArrayList<>();
+            final Set other = (Set)otherObj;
+
+            // Compare size.
+            if (size() != other.size()) return false;
+
+            // Compare all non-sentinel values.
+            final Iterator<Entry<K, V>> iter = iterator();
+            while (iter.hasNext()) {
+                final Entry<K, V> myElem = iter.next();
+                if (internalMap.get(myElem.getKey()) == SENTINEL)
+                    sentinelValues.add(myElem);  // Process sentinels last.
+                else if (!other.contains(myElem))
+                    return false;
+            }
+
+            // Now process sentinels.
+            for (Map.Entry<K, V> myElem : sentinelValues)
+                if (!other.contains(myElem)) return false;
+
+            return true;
+        }
+    }
+
+    private class ValuesCollection implements Collection<V> {
+        @Override
+        public int size() { return LazyMap.this.size(); }
+        @Override
+        public boolean isEmpty() { return LazyMap.this.isEmpty(); }
+
+        @Override
+        public boolean contains(Object o) {
+            return containsAll(singleton(o));
+        }
+
+        @Override
+        public Iterator<V> iterator() {
+            return new Iterator<V>() {
+                private final Iterator<Map.Entry<K, V>> underlying = new EntrySetIterator(internalMap.keySet().iterator());
+
+                @Override
+                public boolean hasNext() { return underlying.hasNext(); }
+                @Override
+                public V next() { return underlying.next().getValue(); }
+                @Override
+                public void remove() { underlying.remove(); }
+            };
+        }
+
+        @Override
+        public Object[] toArray() {
+            final Object[] result = new Object[size()];
+            Iterator<V> iter = iterator();
+            for (int idx = 0; iter.hasNext(); ++idx) {
+                result[idx] = iter.next();
+            }
+            return result;
+        }
+
+        @Override
+        public <T> T[] toArray(T[] a) {
+            if (a.length < size())
+                a = Arrays.copyOf(a, size());
+
+            Iterator<V> iter = iterator();
+            for (int idx = 0; iter.hasNext(); ++idx) {
+                a[idx] = (T)iter.next();
+            }
+            return a;
+        }
+
+        @Override
+        public boolean add(V e) {
+            throw new UnsupportedOperationException("Can't add value without key.");
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            return removeAll(singleton(o));
+        }
+
+        @Override
+        public boolean containsAll(Collection<?> c) {
+            if (c.isEmpty()) return true;
+
+            // Operate on a copy of c, so we can remove items from c instead.
+            Collection<?> copy = new ArrayList<>(c);
+            List<Map.Entry<K, V>> sentinalValues = new ArrayList<>();  // Delay sentinal resolver.
+
+            // Remove all non-sentinel values from copy.
+            final Iterator<Map.Entry<K, V>> iter = new EntrySetIterator(internalMap.keySet().iterator());
+            while (iter.hasNext()) {
+                Map.Entry<K, V> e = iter.next();
+
+                if (internalMap.get(e.getKey()) == SENTINEL)
+                    sentinalValues.add(e);
+                else
+                    copy.remove(e.getValue());
+
+                if (copy.isEmpty()) return true;
+            }
+
+            // Remove all sentinel values from copy.
+            for (Map.Entry<K, V> sentinel : sentinalValues) {
+                copy.remove(sentinel.getValue());
+                if (copy.isEmpty()) return true;
+            }
+
+            assert(!copy.isEmpty());
+            return false;
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends V> c) {
+            throw new UnsupportedOperationException("Can't add values without keys.");
+        }
+
+        @Override
+        public boolean removeAll(Collection<?> c) {
+            boolean changed = false;
+
+            Iterator<V> iter = iterator();
+            while (iter.hasNext()) {
+                V next = iter.next();
+
+                if (c.contains(next)) {
+                    changed = true;
+                    iter.remove();
+                }
+            }
+            return changed;
+        }
+
+        @Override
+        public boolean retainAll(Collection<?> c) {
+            boolean changed = false;
+
+            Iterator<V> iter = iterator();
+            while (iter.hasNext()) {
+                V next = iter.next();
+
+                if (!c.contains(next)) {
+                    changed = true;
+                    iter.remove();
+                }
+            }
+            return changed;
+        }
+
+        @Override
+        public void clear() {
+            LazyMap.this.clear();
+        }
+    }
+}

--- a/lib/src/test/java/com/groupon/lex/metrics/lib/LazyMapTest.java
+++ b/lib/src/test/java/com/groupon/lex/metrics/lib/LazyMapTest.java
@@ -1,0 +1,377 @@
+package com.groupon.lex.metrics.lib;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import static java.util.Collections.EMPTY_LIST;
+import static java.util.Collections.EMPTY_SET;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author ariane
+ */
+public class LazyMapTest {
+    private Map<Integer, Integer> expected;
+    private LazyMap<Integer, Integer> map;
+
+    @Before
+    public void setup() {
+        expected = new HashMap<Integer, Integer>() {{
+            put(1, 1);
+            put(4, 16);
+            put(9, 81);
+        }};
+
+        map = new LazyMap<>(x -> x * x, expected.keySet());
+    }
+
+    @Test
+    public void entrySet() {
+        assertEquals(expected.entrySet(), map.entrySet());
+    }
+
+    @Test
+    public void keySet() {
+        assertEquals(expected.keySet(), map.keySet());
+    }
+
+    @Test
+    public void values() {
+        System.out.println(new ArrayList<>(map.values()));
+        assertThat(map.values(), containsInAnyOrder(1, 16, 81));
+    }
+
+    @Test
+    public void sizeAndEmpty() {
+        Map<Integer, Integer> empty = new LazyMap<>(Function.identity());
+
+        assertTrue(empty.isEmpty());
+        assertEquals(0, empty.size());
+
+        assertFalse(map.isEmpty());
+        assertEquals(expected.size(), map.size());
+    }
+
+    @Test
+    public void get() {
+        assertEquals(1, (int)map.get(1));
+        assertEquals(16, (int)map.get(4));
+        assertEquals(81, (int)map.get(9));
+
+        assertNull(map.get(91));
+        assertNull(map.get(null));
+    }
+
+    @Test
+    public void put() {
+        Integer expectedOld = expected.put(1, 17);
+        Integer mapOld = map.put(1, 17);
+
+        assertEquals(expectedOld, mapOld);
+        assertEquals(expected, map);
+    }
+
+    @Test
+    public void putAll() {
+        expected.putAll(singletonMap(3, 3));
+        map.putAll(singletonMap(3, 3));
+
+        expected.putAll(singletonMap(1, 1));
+        map.putAll(singletonMap(1, 1));
+
+        assertEquals(expected, map);
+    }
+
+    @Test
+    public void remove() {
+        int expectedOld = expected.remove(4);
+        int mapOld = map.remove(4);
+
+        assertEquals(expectedOld, mapOld);
+        assertEquals(expected, map);
+    }
+
+    @Test
+    public void containsKey() {
+        assertTrue(map.containsKey(4));
+        assertFalse(map.containsKey(5));
+    }
+
+    @Test
+    public void containsValue() {
+        assertTrue(map.containsValue(16));
+        assertFalse(map.containsValue(4));
+    }
+
+    @Test
+    public void clear() {
+        expected.clear();
+        map.clear();
+
+        assertTrue(map.isEmpty());
+        assertEquals(0, map.size());
+        assertEquals(expected, map);
+    }
+
+    @Test
+    public void testHashCode() {
+        assertEquals(expected.hashCode(), map.hashCode());
+    }
+
+    @Test
+    public void equality() {
+        assertTrue(map.equals(expected));
+        assertFalse(map.equals(null));
+        assertFalse(map.equals(new Object()));
+        assertFalse(map.equals(singletonMap(1, 1)));
+    }
+
+    @Test
+    public void entrySetHashCode() {
+        assertEquals(expected.entrySet().hashCode(), map.entrySet().hashCode());
+    }
+
+    @Test
+    public void entrySetEquality() {
+        assertTrue(map.entrySet().equals(new HashSet<>(expected.entrySet())));
+        assertFalse(map.entrySet().equals(EMPTY_SET));
+        assertFalse(map.entrySet().equals(new Object()));
+        assertFalse(map.entrySet().equals(null));
+    }
+
+    @Test
+    public void entrySetAddAll() {
+        Set<Map.Entry<Integer, Integer>> toAdd = singleton(SimpleMapEntry.create(3, 8));
+        expected.put(3, 8);
+        map.entrySet().addAll(toAdd);
+
+        assertThat(map, hasEntry(3, 8));
+        assertEquals(expected, map);
+    }
+
+    @Test
+    public void entrySetContainsAll() {
+        Set<Map.Entry<Integer, Integer>> absent = singleton(SimpleMapEntry.create(3, 8));
+        Set<Map.Entry<Integer, Integer>> present = singleton(SimpleMapEntry.create(4, 16));
+        List<Map.Entry<Integer, Integer>> present_and_absent = new ArrayList<Map.Entry<Integer, Integer>>() {{
+            addAll(absent);
+            addAll(present);
+        }};
+
+        assertTrue(map.entrySet().containsAll(present));
+        assertFalse(map.entrySet().containsAll(absent));
+        assertFalse(map.entrySet().containsAll(present_and_absent));
+        assertFalse(map.entrySet().containsAll(singleton(new Object())));
+        assertFalse(map.entrySet().containsAll(singleton(null)));
+    }
+
+    @Test
+    public void entrySetRemoveAll() {
+        Set<Map.Entry<Integer, Integer>> absent = singleton(SimpleMapEntry.create(3, 8));
+        Set<Map.Entry<Integer, Integer>> present = singleton(SimpleMapEntry.create(4, 16));
+        List<Map.Entry<Integer, Integer>> present_and_absent = new ArrayList<Map.Entry<Integer, Integer>>() {{
+            addAll(singletonMap(9, 81).entrySet());  // present
+            addAll(singletonMap(3, 3).entrySet());  // absent
+        }};
+
+        assertFalse(map.entrySet().removeAll(absent));
+        assertEquals(expected, map);
+
+        expected.entrySet().removeAll(present);
+        assertTrue(map.entrySet().removeAll(present));
+        assertEquals(expected, map);
+
+        expected.entrySet().removeAll(present_and_absent);
+        assertTrue(map.entrySet().removeAll(present_and_absent));
+        assertEquals(expected, map);
+    }
+
+    @Test
+    public void entrySetRetainAll() {
+        List<Map.Entry<Integer, Integer>> present_and_absent = new ArrayList<Map.Entry<Integer, Integer>>() {{
+            addAll(singletonMap(9, 81).entrySet());  // present
+            addAll(singletonMap(3, 3).entrySet());  // absent
+            addAll(singletonMap(4, 4).entrySet());  // absent
+        }};
+
+        assertTrue(map.entrySet().retainAll(present_and_absent));
+        assertEquals(singletonMap(9, 81), map);
+    }
+
+    @Test
+    public void entrySetClear() {
+        map.entrySet().clear();
+
+        assertTrue(map.isEmpty());
+    }
+
+    @Test
+    public void entrySetSizeAndEmpty() {
+        Map<Integer, Integer> empty = new LazyMap<>(Function.identity());
+
+        assertEquals(3, map.entrySet().size());
+        assertEquals(0, empty.size());
+
+        assertFalse(map.entrySet().isEmpty());
+        assertTrue(empty.isEmpty());
+    }
+
+    @Test
+    public void entrySetToArray() {
+        Object[] arr = map.entrySet().toArray();
+
+        assertThat(arr, arrayContainingInAnyOrder(
+                SimpleMapEntry.create(1,  1),
+                SimpleMapEntry.create(4, 16),
+                SimpleMapEntry.create(9, 81)));
+    }
+
+    @Test
+    public void entrySetToArrayWithInitializer() {
+        Map.Entry[] init_exact_size = new Map.Entry[3];
+        Map.Entry[] init_too_small = new Map.Entry[2];
+        Map.Entry[] init_empty = new Map.Entry[0];
+        Map.Entry[] init_too_large = new Map.Entry[4];
+
+        Map.Entry[] arr_exact_size = map.entrySet().toArray(init_exact_size);
+        Map.Entry[] arr_too_small = map.entrySet().toArray(init_too_small);
+        Map.Entry[] arr_empty = map.entrySet().toArray(init_empty);
+        Map.Entry[] arr_too_large = map.entrySet().toArray(init_too_large);
+
+        assertSame(init_exact_size, arr_exact_size);
+        assertNotSame(init_too_small, arr_too_small);
+        assertNotSame(init_empty, arr_empty);
+        assertSame(init_too_large, arr_too_large);
+
+        assertThat(arr_exact_size, arrayContainingInAnyOrder(
+                SimpleMapEntry.create(1,  1),
+                SimpleMapEntry.create(4, 16),
+                SimpleMapEntry.create(9, 81)));
+        assertThat(arr_too_small, arrayContainingInAnyOrder(
+                SimpleMapEntry.create(1,  1),
+                SimpleMapEntry.create(4, 16),
+                SimpleMapEntry.create(9, 81)));
+        assertThat(arr_empty, arrayContainingInAnyOrder(
+                SimpleMapEntry.create(1,  1),
+                SimpleMapEntry.create(4, 16),
+                SimpleMapEntry.create(9, 81)));
+        assertThat(Arrays.copyOf(arr_too_large, 3), arrayContainingInAnyOrder(
+                SimpleMapEntry.create(1,  1),
+                SimpleMapEntry.create(4, 16),
+                SimpleMapEntry.create(9, 81)));
+        assertNull(arr_too_large[3]);
+    }
+
+    @Test
+    public void valuesSizeAndEmpty() {
+        Map<?, ?> empty = new LazyMap<>(Function.identity());
+
+        assertEquals(3, map.values().size());
+        assertFalse(map.values().isEmpty());
+
+        assertEquals(0, empty.values().size());
+        assertTrue(empty.values().isEmpty());
+    }
+
+    @Test
+    public void valuesToArray() {
+        Object[] arr = map.values().toArray();
+
+        assertThat(arr, arrayContainingInAnyOrder(1, 16, 81));
+    }
+
+    @Test
+    public void valuesToArrayWithInitializer() {
+        Number[] init_exact_size = new Number[3];
+        Number[] init_too_small = new Number[2];
+        Number[] init_empty = new Number[0];
+        Number[] init_too_large = new Number[4];
+
+        Number[] arr_exact_size = map.values().toArray(init_exact_size);
+        Number[] arr_too_small = map.values().toArray(init_too_small);
+        Number[] arr_empty = map.values().toArray(init_empty);
+        Number[] arr_too_large = map.values().toArray(init_too_large);
+
+        assertSame(init_exact_size, arr_exact_size);
+        assertNotSame(init_too_small, arr_too_small);
+        assertNotSame(init_empty, arr_empty);
+        assertSame(init_too_large, arr_too_large);
+
+        assertThat(arr_exact_size, arrayContainingInAnyOrder(1, 16, 81));
+        assertThat(arr_too_small, arrayContainingInAnyOrder(1, 16, 81));
+        assertThat(arr_empty, arrayContainingInAnyOrder(1, 16, 81));
+        assertThat(Arrays.copyOf(arr_too_large, 3), arrayContainingInAnyOrder(1, 16, 81));
+        assertNull(arr_too_large[3]);
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void valuesAdd() {
+        map.values().add(17);
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void valuesAddAll() {
+        map.values().addAll(EMPTY_LIST);
+    }
+
+    @Test
+    public void valuesRemove() {
+        expected.remove(4, 16);
+
+        assertTrue(map.values().remove(16));
+        assertFalse(map.values().remove(5));
+
+        assertEquals(expected, map);
+    }
+
+    @Test
+    public void valuesRemoveAll() {
+        expected.remove(4, 16);
+        assertTrue(map.values().removeAll(Arrays.asList(16, 17)));
+        assertEquals(expected, map);
+
+        assertFalse(map.values().removeAll(Arrays.asList(-1, -2)));
+        assertEquals(expected, map);
+    }
+
+    @Test
+    public void valuesContains() {
+        assertTrue(map.values().contains(16));
+        assertFalse(map.values().contains(17));
+    }
+
+    @Test
+    public void valuesContainsAll() {
+        assertTrue(map.values().containsAll(Arrays.asList(16, 81)));
+        assertFalse(map.values().containsAll(Arrays.asList(16, 17)));
+    }
+
+    @Test
+    public void valuesRetainAll() {
+        expected.remove(9, 81);
+        assertTrue(map.values().retainAll(Arrays.asList(1, 16)));
+        assertEquals(expected, map);
+
+        assertFalse(map.values().retainAll(Arrays.asList(1, 16, 17)));
+        assertEquals(expected, map);
+    }
+}


### PR DESCRIPTION
Allow for interpolating metric values.
Used by rate() function to get correct rates.

With some modification to the history context resolution, this can also be used to fill in missing metric values and do actual stepping (i.e. make the stepSize parameter a fixed size delta, rather than a at-least-next distance).

https://github.com/groupon/monsoon/pull/39 takes care of the history module, which is needed if this diff is used in combination with a history server accepting data from multiple monsoon instances.