### PR TITLE
History dups

### DIFF
--- a/history/src/main/java/com/groupon/lex/metrics/history/TSData.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/TSData.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
+import static java.util.Spliterator.DISTINCT;
 import static java.util.Spliterator.IMMUTABLE;
 import static java.util.Spliterator.NONNULL;
 import static java.util.Spliterator.ORDERED;
@@ -49,13 +50,20 @@ public interface TSData extends Collection<TimeSeriesCollection>, CollectHistory
     public short getMinor();
     /** Returns true if the file is compressed. */
     public boolean isGzipped();
+    /** Returns true if the file has ordered records. */
+    public boolean isOrdered();
+    /** Returns true if the file records are unique. */
+    public boolean isUnique();
     /** Returns a closeable iterator for this TSData. */
     @Override
     public Iterator<TimeSeriesCollection> iterator();
 
     @Override
     public default Spliterator<TimeSeriesCollection> spliterator() {
-        return Spliterators.spliteratorUnknownSize(iterator(), NONNULL | IMMUTABLE | ORDERED);
+        int flags = NONNULL | IMMUTABLE;
+        if (isOrdered()) flags |= ORDERED;
+        if (isUnique()) flags |= DISTINCT;
+        return Spliterators.spliteratorUnknownSize(iterator(), flags);
     }
 
     /** Stream the TSData contents. */

--- a/history/src/main/java/com/groupon/lex/metrics/history/TSData.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/TSData.java
@@ -21,6 +21,7 @@ import static java.util.Spliterator.DISTINCT;
 import static java.util.Spliterator.IMMUTABLE;
 import static java.util.Spliterator.NONNULL;
 import static java.util.Spliterator.ORDERED;
+import static java.util.Spliterator.SORTED;
 import java.util.Spliterators;
 import java.util.function.Predicate;
 import java.util.logging.Level;
@@ -54,24 +55,35 @@ public interface TSData extends Collection<TimeSeriesCollection>, CollectHistory
     public boolean isOrdered();
     /** Returns true if the file records are unique. */
     public boolean isUnique();
-    /** Returns a closeable iterator for this TSData. */
+    /**
+     * Returns an iterator for this TSData.
+     * Iterator is always ordered, without duplicate timestamps.
+     */
     @Override
     public Iterator<TimeSeriesCollection> iterator();
 
+    /**
+     * Returns an iterator for this TSData.
+     * Iterator is always ordered, without duplicate timestamps.
+     */
     @Override
     public default Spliterator<TimeSeriesCollection> spliterator() {
-        int flags = NONNULL | IMMUTABLE;
-        if (isOrdered()) flags |= ORDERED;
-        if (isUnique()) flags |= DISTINCT;
-        return Spliterators.spliteratorUnknownSize(iterator(), flags);
+        return Spliterators.spliteratorUnknownSize(iterator(), NONNULL | IMMUTABLE | ORDERED | DISTINCT | SORTED);
     }
 
-    /** Stream the TSData contents. */
+    /**
+     * Stream the TSData contents.
+     * The stream iterates collection in chronological order, without duplicate timestamps.
+     */
     @Override
     public default Stream<TimeSeriesCollection> stream() {
         return StreamSupport.stream(spliterator(), false);
     }
 
+    /**
+     * Stream the TSData contents in reverse chronological order.
+     * The stream iterates collection in reverse chronological order, without duplicate timestamps.
+     */
     @Override
     public default Stream<TimeSeriesCollection> streamReversed() {
         final List<TimeSeriesCollection> copy = stream().collect(Collectors.toList());

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/TSDataFileChain.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/TSDataFileChain.java
@@ -30,6 +30,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
+import static java.util.Spliterator.DISTINCT;
 import static java.util.Spliterator.IMMUTABLE;
 import static java.util.Spliterator.NONNULL;
 import static java.util.Spliterator.ORDERED;
@@ -39,6 +40,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
+import lombok.Getter;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -50,6 +52,8 @@ public class TSDataFileChain implements TSData {
     private static final Logger LOG = Logger.getLogger(TSDataFileChain.class.getName());
     public static long MAX_FILESIZE = 64 * 1024 * 1024;
     private final long max_filesize_;
+    @Getter
+    private final boolean ordered = true, unique = true;
 
     public static class Key implements Comparable<Key> {
         private final Path file_;
@@ -229,7 +233,7 @@ public class TSDataFileChain implements TSData {
 
     @Override
     public Spliterator<TimeSeriesCollection> spliterator() {
-        return Spliterators.spliteratorUnknownSize(iterator(), NONNULL | IMMUTABLE | ORDERED);
+        return Spliterators.spliteratorUnknownSize(iterator(), NONNULL | IMMUTABLE | ORDERED | DISTINCT);
     }
 
     @Override

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/TSDataFileChain.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/TSDataFileChain.java
@@ -5,7 +5,6 @@ import com.groupon.lex.metrics.history.TSData;
 import com.groupon.lex.metrics.history.xdr.TSDataScanDir.MetaData;
 import com.groupon.lex.metrics.history.xdr.support.MultiFileIterator;
 import com.groupon.lex.metrics.history.xdr.support.TSDataMap;
-import com.groupon.lex.metrics.lib.SimpleMapEntry;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
@@ -21,26 +20,26 @@ import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.Collections;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.reverse;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Spliterator;
 import static java.util.Spliterator.DISTINCT;
 import static java.util.Spliterator.IMMUTABLE;
 import static java.util.Spliterator.NONNULL;
 import static java.util.Spliterator.ORDERED;
 import java.util.Spliterators;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import java.util.zip.GZIPOutputStream;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -53,8 +52,6 @@ public class TSDataFileChain implements TSData {
     private static final Logger LOG = Logger.getLogger(TSDataFileChain.class.getName());
     public static long MAX_FILESIZE = 64 * 1024 * 1024;
     private final long max_filesize_;
-    @Getter
-    private final boolean ordered = true, unique = true;
 
     public static class Key implements Comparable<Key> {
         private final Path file_;
@@ -203,59 +200,46 @@ public class TSDataFileChain implements TSData {
         }
     }
 
-    private Stream<Map.Entry<Key, TSData>> stream_datafiles_() {
-        Stream<Map.Entry<Key, TSData>> read = read_stores_.entrySet().stream()
-                .sorted(Comparator.comparing(entry -> entry.getKey().getBegin()));
-
-        Optional<WriteableTSDataFile> opt_ws;
-        try {
-            opt_ws = get_write_store_();
-        } catch (IOException ex) {
-            opt_ws = Optional.empty();
-        }
-        Stream<Map.Entry<Key, TSData>> write = opt_ws
-                .flatMap(ws -> write_filename_.map(name -> SimpleMapEntry.create(name, ws)))
-                .map(named_ws -> {
-                    final Path name = named_ws.getKey();
-                    final WriteableTSDataFile ws = named_ws.getValue();
-                    final Key key = new Key(name, ws.getBegin(), ws.getEnd());
-                    return SimpleMapEntry.<Key, TSData>create(key, ws);
-                })
-                .map(Stream::of)
-                .orElseGet(Stream::empty);
-
-        return Stream.concat(read, write);
+    @AllArgsConstructor
+    @Getter
+    private static abstract class TSDataSupplier implements MultiFileIterator.TSDataSupplier {
+        private final DateTime begin;
+        private final DateTime end;
     }
 
-    private Stream<MultiFileIterator.TSDataSupplier> stream_tsdata_suppliers_() {
-        Stream<MultiFileIterator.TSDataSupplier> wfileStream;
+    private Stream<TSData> stream_datafiles_() {
+        Stream<TSData> wfileStream;
+        try {
+            wfileStream = get_write_store_().map(Stream::<TSData>of).orElseGet(Stream::empty);
+        } catch (IOException ex) {
+            wfileStream = Stream.empty();
+        }
+
+        final Stream<TSData> rfileStream = read_stores_.entrySet().stream()
+                .map(rfile -> rfile.getValue());
+
+        return Stream.concat(wfileStream, rfileStream);
+    }
+
+    private Stream<TSDataSupplier> stream_tsdata_suppliers_(Function<TSData, Iterator<TimeSeriesCollection>> iteratorFn) {
+        Stream<TSDataSupplier> wfileStream;
         try {
             wfileStream = get_write_store_().map(Stream::of).orElseGet(Stream::empty)
-                    .map(wfile -> new MultiFileIterator.TSDataSupplier() {
-                        @Override
-                        public DateTime getBegin() {
-                            return wfile.getBegin();
-                        }
-
+                    .map(wfile -> new TSDataSupplier(wfile.getBegin(), wfile.getEnd()) {
                         @Override
                         public Iterator<TimeSeriesCollection> getIterator() {
-                            return wfile.iterator();
+                            return iteratorFn.apply(wfile);
                         }
                     });
         } catch (IOException ex) {
             wfileStream = Stream.empty();
         }
 
-        final Stream<MultiFileIterator.TSDataSupplier> rfileStream = read_stores_.entrySet().stream()
-                .map(rfile -> new MultiFileIterator.TSDataSupplier() {
-                    @Override
-                    public DateTime getBegin() {
-                        return rfile.getKey().getBegin();
-                    }
-
+        final Stream<TSDataSupplier> rfileStream = read_stores_.entrySet().stream()
+                .map(rfile -> new TSDataSupplier(rfile.getKey().getBegin(), rfile.getKey().getEnd()) {
                     @Override
                     public Iterator<TimeSeriesCollection> getIterator() {
-                        return rfile.getValue().iterator();
+                        return iteratorFn.apply(rfile.getValue());
                     }
                 });
 
@@ -264,46 +248,42 @@ public class TSDataFileChain implements TSData {
 
     @Override
     public Iterator<TimeSeriesCollection> iterator() {
-        return new MultiFileIterator(stream_tsdata_suppliers_().collect(Collectors.toList()));
-    }
-
-    @Override
-    public Spliterator<TimeSeriesCollection> spliterator() {
-        return Spliterators.spliteratorUnknownSize(iterator(), NONNULL | IMMUTABLE | ORDERED | DISTINCT);
-    }
-
-    @Override
-    public Stream<TimeSeriesCollection> stream() {
-        return stream_datafiles_()
-                .map(Map.Entry::getValue)
-                .flatMap(TSData::stream);
+        return new MultiFileIterator(stream_tsdata_suppliers_(TSData::iterator).collect(Collectors.toList()), Comparator.naturalOrder());
     }
 
     @Override
     public Stream<TimeSeriesCollection> streamReversed() {
-        final List<TSData> reversed = stream_datafiles_()
-                .map(Map.Entry::getValue)
-                .collect(Collectors.toList());
-        reverse(reversed);
-        return reversed.stream()
-                .flatMap(TSData::streamReversed);
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(
+                        new MultiFileIterator(stream_tsdata_suppliers_(tsdata -> tsdata.streamReversed().iterator()).collect(Collectors.toList()),
+                                Comparator.reverseOrder()),
+                        NONNULL | IMMUTABLE | ORDERED | DISTINCT),
+                false);
     }
 
     @Override
     public Stream<TimeSeriesCollection> stream(DateTime begin) {
-        return stream_datafiles_()
-                .filter(tsd -> !begin.isAfter(tsd.getKey().getEnd()))
-                .map(Map.Entry::getValue)
-                .flatMap(TSData::stream)
+        final List<TSDataSupplier> files = stream_tsdata_suppliers_(TSData::iterator)
+                .filter(tsd -> !begin.isAfter(tsd.getEnd()))
+                .collect(Collectors.toList());
+        return StreamSupport.stream(
+                    Spliterators.spliteratorUnknownSize(
+                            new MultiFileIterator(files, Comparator.naturalOrder()),
+                            NONNULL | IMMUTABLE | ORDERED | DISTINCT),
+                    false)
                 .filter(tsc -> !tsc.getTimestamp().isBefore(begin));
     }
 
     @Override
     public Stream<TimeSeriesCollection> stream(DateTime begin, DateTime end) {
-        return stream_datafiles_()
-                .filter(tsd -> !begin.isAfter(tsd.getKey().getEnd()) && !end.isBefore(tsd.getKey().getBegin()))
-                .map(Map.Entry::getValue)
-                .flatMap(TSData::stream)
+        final List<TSDataSupplier> files = stream_tsdata_suppliers_(TSData::iterator)
+                .filter(tsd -> !begin.isAfter(tsd.getEnd()) && !end.isBefore(tsd.getBegin()))
+                .collect(Collectors.toList());
+        return StreamSupport.stream(
+                    Spliterators.spliteratorUnknownSize(
+                            new MultiFileIterator(files, Comparator.naturalOrder()),
+                            NONNULL | IMMUTABLE | ORDERED | DISTINCT),
+                    false)
                 .filter(tsc -> !tsc.getTimestamp().isBefore(begin))
                 .filter(tsc -> !tsc.getTimestamp().isAfter(end));
     }
@@ -311,7 +291,6 @@ public class TSDataFileChain implements TSData {
     @Override
     public boolean isEmpty() {
         return stream_datafiles_()
-                .map(Map.Entry::getValue)
                 .allMatch(TSData::isEmpty);
     }
 
@@ -323,7 +302,6 @@ public class TSDataFileChain implements TSData {
     @Override
     public int size() {
         return stream_datafiles_()
-                .map(Map.Entry::getValue)
                 .mapToInt(TSData::size)
                 .sum();
     }
@@ -335,9 +313,8 @@ public class TSDataFileChain implements TSData {
         final TimeSeriesCollection tsv = (TimeSeriesCollection)o;
         final DateTime ts = tsv.getTimestamp();
         return stream_datafiles_()
-                .filter(tsd -> !ts.isBefore(tsd.getKey().getBegin()))
-                .filter(tsd -> !ts.isAfter(tsd.getKey().getEnd()))
-                .map(Map.Entry::getValue)
+                .filter(tsd -> !ts.isBefore(tsd.getBegin()))
+                .filter(tsd -> !ts.isAfter(tsd.getEnd()))
                 .anyMatch(tsd -> tsd.contains(tsv));
     }
 
@@ -354,10 +331,9 @@ public class TSDataFileChain implements TSData {
         }
 
         boolean matches = stream_datafiles_()
-                .unordered()
                 .allMatch(tsd -> {
-                    final DateTime begin = tsd.getKey().getBegin();
-                    final DateTime end = tsd.getKey().getEnd();
+                    final DateTime begin = tsd.getBegin();
+                    final DateTime end = tsd.getEnd();
                     final List<TimeSeriesCollection> filter = tsc_list.stream()
                             .filter(tsc -> !tsc.getTimestamp().isBefore(begin))
                             .filter(tsc -> !tsc.getTimestamp().isAfter(end))
@@ -365,7 +341,7 @@ public class TSDataFileChain implements TSData {
 
                     if (!filter.isEmpty()) {
                         tsc_list.removeAll(filter);
-                        return tsd.getValue().containsAll(filter);
+                        return tsd.containsAll(filter);
                     } else {
                         return true;
                     }
@@ -626,4 +602,9 @@ public class TSDataFileChain implements TSData {
             LOG.log(Level.WARNING, "unable to remove file " + key.getFile(), ex);
         }
     }
+
+    @Override
+    public boolean isOrdered() { return true; }
+    @Override
+    public boolean isUnique() { return true; }
 }

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/WriteableTSDataFile.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/WriteableTSDataFile.java
@@ -35,14 +35,16 @@ import java.util.stream.Stream;
 import org.acplt.oncrpc.OncRpcException;
 import com.groupon.lex.metrics.history.xdr.support.XdrBufferDecodingStream;
 import com.groupon.lex.metrics.history.xdr.support.XdrBufferEncodingStream;
+import lombok.Getter;
 import org.joda.time.DateTime;
 
-public class WriteableTSDataFile implements TSData {
+public final class WriteableTSDataFile implements TSData {
     private final GCCloseable<FileChannel> fd_;
-    private final Path file_;
     private SoftReference<TSData> readonly_ = new SoftReference<>(null);
     private final HeaderRegenerator header_regenerator_;
     private final FromXdr from_xdr_ = new FromXdr();
+    @Getter
+    private boolean ordered, unique;
 
     private static class PositionalReader implements BufferSupplier {
         private final GCCloseable<FileChannel> fd_;
@@ -115,8 +117,14 @@ public class WriteableTSDataFile implements TSData {
             write_buffer_to_file_(xdr.getBuffers(), 0);
         }
 
-        public void updateTimestamp(DateTime new_end_ts) throws IOException {
+        public void updateTimestamp(DateTime new_end_ts, Runnable onUnordered, Runnable onNotUnique) throws IOException {
             final long new_ts = ToXdr.timestamp(new_end_ts).value;
+
+            if (hdr_.last.value < new_ts)
+                onUnordered.run();
+            if (hdr_.last.value == new_ts)
+                onNotUnique.run();
+
             if (need_upgrade_ || hdr_.last.value < new_ts || hdr_.first.value > new_ts) {
                 hdr_.last.value = max(hdr_.last.value, new_ts);
                 hdr_.first.value = min(hdr_.first.value, new_ts);
@@ -147,9 +155,8 @@ public class WriteableTSDataFile implements TSData {
         }
     }
 
-    private WriteableTSDataFile(Path file, GCCloseable<FileChannel> fd) throws IOException {
+    private WriteableTSDataFile(GCCloseable<FileChannel> fd) throws IOException {
         header_regenerator_ = new HeaderRegenerator(fd);  // Validates header.
-        file_ = file;
         fd_ = requireNonNull(fd);
 
         /*
@@ -173,11 +180,36 @@ public class WriteableTSDataFile implements TSData {
         } catch (OncRpcException ex) {
             throw new IOException("RPC decoding error", ex);
         }
+
+        /*
+         * Check if the collection is ordered and unique.
+         */
+        final Iterator<TimeSeriesCollection> iter = iterator();
+        if (!iter.hasNext()) {
+            ordered = true;
+            unique = true;
+        } else {
+            boolean uniqueLoopInvariant = true;
+            boolean orderedLoopInvariant = true;
+
+            DateTime ts = iter.next().getTimestamp();
+            while (iter.hasNext()) {
+                final DateTime nextTs = iter.next().getTimestamp();
+
+                if (ts.equals(nextTs))
+                    uniqueLoopInvariant = false;
+                if (nextTs.isBefore(ts))
+                    orderedLoopInvariant = false;
+            }
+
+            ordered = orderedLoopInvariant;
+            unique = uniqueLoopInvariant;
+        }
     }
 
     public static WriteableTSDataFile open(Path file) throws IOException {
         final GCCloseable<FileChannel> fd = new GCCloseable<>(FileChannel.open(file, READ, WRITE));
-        return new WriteableTSDataFile(file, fd);
+        return new WriteableTSDataFile(fd);
     }
 
     public static WriteableTSDataFile newFile(Path file, DateTime begin, DateTime end) throws IOException {
@@ -196,8 +228,8 @@ public class WriteableTSDataFile implements TSData {
 
         final GCCloseable<FileChannel> fd = new GCCloseable<>(FileChannel.open(file, READ, WRITE, CREATE_NEW));
         try {
-            write_buffers_(fd.get(), xdr.getBuffers(), null, null);
-            return new WriteableTSDataFile(file, fd);
+            write_buffers_(fd.get(), xdr.getBuffers(), null, null, () -> {}, () -> {});
+            return new WriteableTSDataFile(fd);
         } catch (IOException | RuntimeException ex) {
             Files.delete(file);
             throw ex;
@@ -208,7 +240,7 @@ public class WriteableTSDataFile implements TSData {
         TSData result = readonly_.get();
         if (result == null) {
             try {
-                result = new UnmappedReadonlyTSDataFile(fd_);
+                result = new UnmappedReadonlyTSDataFile(fd_, ordered, unique);
             } catch (IOException ex) {
                 Logger.getLogger(WriteableTSDataFile.class.getName()).log(Level.SEVERE, "read-only stream failed", ex);
                 throw new RuntimeException("read-only stream failed", ex);
@@ -243,7 +275,7 @@ public class WriteableTSDataFile implements TSData {
         return get_readonly_().toArray(a);
     }
 
-    private static boolean write_buffers_(FileChannel fd, List<ByteBuffer> bufs, HeaderRegenerator header_regenerator, DateTime new_end) throws IOException {
+    private static boolean write_buffers_(FileChannel fd, List<ByteBuffer> bufs, HeaderRegenerator header_regenerator, DateTime new_end, Runnable onUnordered, Runnable onNotUnique) throws IOException {
         boolean wrote_something = false;
 
         final long rollback;
@@ -265,7 +297,7 @@ public class WriteableTSDataFile implements TSData {
             }
 
             if (header_regenerator != null)
-                header_regenerator.updateTimestamp(requireNonNull(new_end));
+                header_regenerator.updateTimestamp(requireNonNull(new_end), onUnordered, onNotUnique);
         } catch (RuntimeException | IOException ex) {
             try {
                 fd.truncate(rollback);
@@ -280,7 +312,7 @@ public class WriteableTSDataFile implements TSData {
 
     private synchronized boolean write_buffers_(List<ByteBuffer> bufs, DateTime new_end) {
         try {
-            boolean wrote_something = write_buffers_(fd_.get(), bufs, header_regenerator_, new_end);
+            boolean wrote_something = write_buffers_(fd_.get(), bufs, header_regenerator_, new_end, () -> ordered = false, () -> unique = false);
             if (wrote_something)
                 readonly_.clear();
             return wrote_something;

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/FileIterator.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/FileIterator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics.history.xdr.support;
+
+import com.groupon.lex.metrics.timeseries.BackRefTimeSeriesCollection;
+import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+/**
+ * Small iterator wrapper that merges subsequent items.
+ * @author ariane
+ */
+public class FileIterator implements Iterator<TimeSeriesCollection> {
+    private final Iterator<TimeSeriesCollection> iter;
+    private TimeSeriesCollection next;
+
+    public FileIterator(Iterator<TimeSeriesCollection> iter) {
+        this.iter = iter;
+
+        if (this.iter.hasNext())
+            next = this.iter.next();
+        else
+            next = null;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return next != null;
+    }
+
+    @Override
+    public TimeSeriesCollection next() {
+        TimeSeriesCollection result = next;
+        if (iter.hasNext()) {
+            next = iter.next();
+        } else {
+            next = null;
+            return result;
+        }
+
+        Collection<TimeSeriesCollection> tsMerge = new ArrayList<>();
+        while (next != null && next.getTimestamp().equals(result.getTimestamp())) {
+            tsMerge.add(next);
+            if (iter.hasNext())
+                next = iter.next();
+            else
+                next = null;
+        }
+        result = new BackRefTimeSeriesCollection(
+                result.getTimestamp(),
+                Stream.concat(
+                        result.getTSValues().stream(),
+                        tsMerge.stream().flatMap(c -> c.getTSValues().stream())));
+        return result;
+    }
+}

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/FileTimeSeriesCollection.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/FileTimeSeriesCollection.java
@@ -5,6 +5,7 @@ import com.groupon.lex.metrics.MetricName;
 import com.groupon.lex.metrics.MetricValue;
 import com.groupon.lex.metrics.SimpleGroupPath;
 import com.groupon.lex.metrics.Tags;
+import com.groupon.lex.metrics.timeseries.AbstractTimeSeriesCollection;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
 import com.groupon.lex.metrics.timeseries.TimeSeriesValue;
 import com.groupon.lex.metrics.timeseries.TimeSeriesValueSet;
@@ -12,7 +13,6 @@ import gnu.trove.map.hash.THashMap;
 import java.util.Collection;
 import static java.util.Collections.unmodifiableCollection;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BinaryOperator;
@@ -26,7 +26,7 @@ import org.joda.time.DateTime;
  *
  * @author ariane
  */
-public class FileTimeSeriesCollection implements TimeSeriesCollection {
+public class FileTimeSeriesCollection extends AbstractTimeSeriesCollection implements TimeSeriesCollection {
     private final DateTime timestamp_;
     private final Map<SimpleGroupPath, Map<Tags, TimeSeriesValue>> path_map_;
 
@@ -117,31 +117,6 @@ public class FileTimeSeriesCollection implements TimeSeriesCollection {
     @Override
     public TimeSeriesCollection clone() {
         return this;  // Immutable
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = 7;
-        hash = 97 * hash + Objects.hashCode(this.timestamp_);
-        return hash;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final FileTimeSeriesCollection other = (FileTimeSeriesCollection) obj;
-        if (!Objects.equals(this.timestamp_, other.timestamp_)) {
-            return false;
-        }
-        if (!Objects.equals(path_map_, other.path_map_)) {
-            return false;
-        }
-        return true;
     }
 
     @Override

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/MultiFileIterator.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/MultiFileIterator.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics.history.xdr.support;
+
+import com.groupon.lex.metrics.timeseries.BackRefTimeSeriesCollection;
+import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.PriorityQueue;
+import java.util.stream.Stream;
+import lombok.NonNull;
+import org.joda.time.DateTime;
+
+/**
+ * Iterator that traverses multiple TSData sources.
+ *
+ * The iterator will take care of emitting elements in order and merging duplicate
+ * entries together.
+ * @author ariane
+ */
+public class MultiFileIterator implements Iterator<TimeSeriesCollection> {
+    private final PriorityQueue<TSDataSupplier> files = new PriorityQueue<>(Comparator.comparing(TSDataSupplier::getBegin));
+    private final PriorityQueue<PeekableIterator> fileIters = new PriorityQueue<>(Comparator.comparing(iter -> iter.peek().getTimestamp()));
+
+    public MultiFileIterator(Collection<? extends TSDataSupplier> files) {
+        this.files.addAll(files);
+        updateFileIters();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return !fileIters.isEmpty();
+    }
+
+    @Override
+    public TimeSeriesCollection next() {
+        return getNextCollection();
+    }
+
+    private TimeSeriesCollection getNextCollection() {
+        final PeekableIterator f0 = fileIters.poll();
+        if (f0 == null) throw new NoSuchElementException();
+        TimeSeriesCollection next = f0.next();
+        if (f0.hasNext())
+            fileIters.add(f0);  // Re-insert at new position.
+
+        List<TimeSeriesCollection> tsMerge = new ArrayList<>();
+        for (;;) {
+            final PeekableIterator fn = fileIters.peek();
+            if (fn == null) break;
+            if (!next.getTimestamp().equals(fn.peek().getTimestamp())) break;
+            final PeekableIterator removed = fileIters.poll();
+            assert(fn == removed);
+
+            tsMerge.add(fn.next());
+            if (fn.hasNext())
+                fileIters.add(fn);  // Re-insert at new position.
+        }
+
+        /*
+         * If multiple TS Collections share the same timestamp, merge them together.
+         */
+        if (!tsMerge.isEmpty()) {
+            next = new BackRefTimeSeriesCollection(
+                    next.getTimestamp(),
+                    Stream.concat(next.getTSValues().stream(), tsMerge.stream().flatMap(c -> c.getTSValues().stream())));
+        }
+
+        updateFileIters();  // Update file iters after using them.
+        return next;
+    }
+
+    private void updateFileIters() {
+        // Ensure at least 1 iterator is present in fileIters.
+        while (fileIters.isEmpty()) {
+            final TSDataSupplier f0 = files.poll();
+            if (f0 == null)
+                return;  // No more iterators to create.
+            final Iterator<TimeSeriesCollection> f0_iter = f0.getIterator();
+            if (f0_iter.hasNext())
+                fileIters.add(new PeekableIterator(f0_iter));
+        }
+
+        // Add all iterators that start at/before current element of fileIters head.
+        final DateTime ts = fileIters.peek().peek().getTimestamp();
+        for (;;) {
+            final TSDataSupplier f0 = files.peek();
+            if (f0 == null) break;
+            if (ts.isBefore(f0.getBegin())) break;
+            final TSDataSupplier removed = files.poll(); // Use f0.
+            assert(f0 == removed);
+
+            final Iterator<TimeSeriesCollection> newIter = f0.getIterator();
+            if (newIter.hasNext())
+                fileIters.add(new PeekableIterator(newIter));
+        }
+    }
+
+    /**
+     * Interface to be implemented for files handled by this iterator.
+     */
+    public static interface TSDataSupplier {
+        /** Get the begin timestamp of this file. */
+        public DateTime getBegin();
+        /**
+         * Get an iterator iterating this file.
+         *
+         * The iterator must traverse elements in chronological order.
+         * Each returned element must have a timestamp at/after getBegin().
+         * @return An iterator over the collections in the current file.
+         */
+        public Iterator<TimeSeriesCollection> getIterator();
+    }
+
+    /**
+     * Simple iterator wrapper that allows us to look at the next element without
+     * consuming it.
+     */
+    private static class PeekableIterator implements Iterator<TimeSeriesCollection> {
+        private final Iterator<TimeSeriesCollection> iter;
+        private TimeSeriesCollection next;
+
+        public PeekableIterator(@NonNull Iterator<TimeSeriesCollection> iter) {
+            this.iter = iter;
+            if (this.iter.hasNext())
+                next = this.iter.next();
+            else
+                next = null;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return next != null;
+        }
+
+        @Override
+        public TimeSeriesCollection next() {
+            final TimeSeriesCollection result = next;
+            if (result == null)
+                throw new NoSuchElementException();
+            if (iter.hasNext())
+                next = iter.next();
+            else
+                next = null;
+            return result;
+        }
+
+        public TimeSeriesCollection peek() {
+            if (next == null) throw new NoSuchElementException();
+            return next;
+        }
+    }
+}

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/TSDataTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/TSDataTest.java
@@ -359,6 +359,18 @@ public class TSDataTest {
         }
 
         @Override
+        public boolean isUnique() {
+            fail("unimplemented mock function");
+            return true;
+        }
+
+        @Override
+        public boolean isOrdered() {
+            fail("unimplemented mock function");
+            return true;
+        }
+
+        @Override
         public Iterator<TimeSeriesCollection> iterator() {
             fail("unimplemented mock function");
             return null;

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/BackRefTimeSeriesCollection.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/BackRefTimeSeriesCollection.java
@@ -55,7 +55,7 @@ import org.joda.time.Duration;
  * It remembers older values that are not present after merging in a new set,
  * so that rate queries and back-referencing queries can still get data.
  */
-public class BackRefTimeSeriesCollection implements TimeSeriesCollection {
+public class BackRefTimeSeriesCollection extends AbstractTimeSeriesCollection implements TimeSeriesCollection {
     public static final Duration MAX_AGE = Duration.standardMinutes(30);
     private DateTime timestamp_;
     private final Map<GroupName, TimeSeriesValue> data_ = new THashMap<>();

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollection.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollection.java
@@ -43,7 +43,6 @@ import static java.util.Collections.unmodifiableSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import java.util.Set;
@@ -57,7 +56,7 @@ import org.joda.time.DateTimeZone;
  *
  * @author ariane
  */
-public class MutableTimeSeriesCollection implements TimeSeriesCollection, Cloneable {
+public class MutableTimeSeriesCollection extends AbstractTimeSeriesCollection implements TimeSeriesCollection, Cloneable {
     private static final Logger LOG = Logger.getLogger(MutableTimeSeriesCollection.class.getName());
 
     private DateTime timestamp_;
@@ -196,31 +195,6 @@ public class MutableTimeSeriesCollection implements TimeSeriesCollection, Clonea
     @Override
     public MutableTimeSeriesCollection clone() {
         return new MutableTimeSeriesCollection(getTimestamp(), getData().values().stream());
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = 7;
-        hash = 59 * hash + Objects.hashCode(this.timestamp_);
-        return hash;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final MutableTimeSeriesCollection other = (MutableTimeSeriesCollection) obj;
-        if (!Objects.equals(this.timestamp_, other.timestamp_)) {
-            return false;
-        }
-        if (!Objects.equals(this.data_, other.data_)) {
-            return false;
-        }
-        return true;
     }
 
     @Override

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/AbstractTimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/AbstractTimeSeriesCollection.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics.timeseries;
+
+import java.util.Collection;
+import java.util.Objects;
+import lombok.NonNull;
+
+/**
+ * Helper base class, that implements equals and hashCode for TimeSeriesCollection.
+ */
+public abstract class AbstractTimeSeriesCollection implements TimeSeriesCollection {
+    @Override
+    public final int hashCode() {
+        return hashCode(this);
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof TimeSeriesCollection)) {
+            return false;
+        }
+        final TimeSeriesCollection other = (TimeSeriesCollection) obj;
+        return equals(this, other);
+    }
+
+    @Override
+    public abstract TimeSeriesCollection clone();
+
+    public static int hashCode(@NonNull TimeSeriesCollection c) {
+        return c.getTimestamp().hashCode();
+    }
+
+    public static boolean equals(@NonNull TimeSeriesCollection a, @NonNull TimeSeriesCollection b) {
+        if (!Objects.equals(a.getTimestamp(), b.getTimestamp()))
+            return false;
+        final Collection<TimeSeriesValue> aTSData = a.getTSValues();
+        final Collection<TimeSeriesValue> bTSData = b.getTSValues();
+        return aTSData.containsAll(bTSData) && bTSData.containsAll(aTSData);
+    }
+}

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollection.java
@@ -48,7 +48,7 @@ import org.joda.time.DateTimeZone;
  *
  * @author ariane
  */
-public interface TimeSeriesCollection extends Cloneable {
+public interface TimeSeriesCollection extends Cloneable, Comparable<TimeSeriesCollection> {
     public static DateTime now() {
         return DateTime.now(DateTimeZone.UTC);
     }
@@ -76,4 +76,9 @@ public interface TimeSeriesCollection extends Cloneable {
     }
 
     public TimeSeriesCollection clone();
+
+    @Override
+    public default int compareTo(TimeSeriesCollection o) {
+        return getTimestamp().compareTo(o.getTimestamp());
+    }
 }

--- a/remote_history/src/main/java/com/groupon/monsoon/remote/history/RpcTimeSeriesCollection.java
+++ b/remote_history/src/main/java/com/groupon/monsoon/remote/history/RpcTimeSeriesCollection.java
@@ -36,6 +36,7 @@ import com.groupon.lex.metrics.MetricName;
 import com.groupon.lex.metrics.MetricValue;
 import com.groupon.lex.metrics.SimpleGroupPath;
 import com.groupon.lex.metrics.Tags;
+import com.groupon.lex.metrics.timeseries.AbstractTimeSeriesCollection;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
 import com.groupon.lex.metrics.timeseries.TimeSeriesValue;
 import com.groupon.lex.metrics.timeseries.TimeSeriesValueSet;
@@ -50,13 +51,11 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.joda.time.DateTime;
 
-@EqualsAndHashCode
 @ToString
-public class RpcTimeSeriesCollection implements TimeSeriesCollection {
+public class RpcTimeSeriesCollection extends AbstractTimeSeriesCollection implements TimeSeriesCollection {
     private final DateTime timestamp_;
     private final Map<SimpleGroupPath, Map<Tags, TimeSeriesValue>> path_map_;
 


### PR DESCRIPTION
Allow history module to deal with out-of-order and duplicate history entries.

- Out-of-order entries are reordered.
- Collections with the same timestamp are merged (overwriting groups in undefined order if need be).
- Files intersecting their time range are merged.