### PR TITLE
Add history-size option for history server.

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -28,6 +28,11 @@
             <artifactId>joda-time</artifactId>
             <version>2.8</version>
         </dependency>
+        <dependency>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+            <version>2.33</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/lib/src/main/java/com/groupon/lex/metrics/lib/BytesParser.java
+++ b/lib/src/main/java/com/groupon/lex/metrics/lib/BytesParser.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2016, Ariane van der Steldt
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics.lib;
+
+import static java.util.Collections.unmodifiableMap;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.OptionDef;
+import org.kohsuke.args4j.spi.OptionHandler;
+import org.kohsuke.args4j.spi.Parameters;
+import org.kohsuke.args4j.spi.Setter;
+
+public class BytesParser {
+    public static final Map<Character, Long> SIZE_MAP;
+
+    static {
+        Map<Character, Long> sizeMap = new HashMap<>();
+        sizeMap.put('k', 1L << 10);
+        sizeMap.put('M', 1L << 20);
+        sizeMap.put('G', 1L << 30);
+        sizeMap.put('T', 1L << 40);
+        sizeMap.put('P', 1L << 50);
+        sizeMap.put('E', 1L << 60);
+        SIZE_MAP = unmodifiableMap(sizeMap);
+    }
+
+    public static long parse(String s) {
+        final char lastChar;
+        try {
+            lastChar = s.charAt(s.length() - 1);
+        } catch (IndexOutOfBoundsException ex) {
+            throw new IllegalArgumentException("\"\" is not a valid size");
+        }
+
+        final char lastCharLower = Character.toLowerCase(lastChar);
+        final char lastCharUpper = Character.toUpperCase(lastChar);
+        final Long mul = SIZE_MAP.getOrDefault(lastCharUpper, SIZE_MAP.get(lastCharLower));
+        if (mul != null)
+            s = s.substring(0, s.length() - 1);
+
+        final long v;
+        try {
+            v = Long.parseLong(s);
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("\"" + s + "\" is not a number");
+        }
+
+        return v * (mul == null ? 1L : mul.longValue());
+    }
+
+    public static String render(long v) {
+        return SIZE_MAP.entrySet().stream()
+                .map(spec -> {
+                    return Optional.of(v)
+                            .filter(vv -> vv >= spec.getValue())
+                            .filter(vv -> vv % spec.getValue() == 0)
+                            .map(vv -> vv / spec.getValue())
+                            .map(vv -> SimpleMapEntry.create(vv, spec.getKey()));
+                })
+                .flatMap(opt -> opt.map(Stream::of).orElseGet(Stream::empty))
+                .min(Comparator.comparing(Map.Entry::getKey))
+                .map(v_with_spec -> v_with_spec.getKey().toString() + v_with_spec.getValue().toString())
+                .orElseGet(() -> Long.toString(v));
+    }
+
+    public static class BytesParserOptionHandler extends OptionHandler<Long> {
+        public BytesParserOptionHandler(CmdLineParser parser, OptionDef option, Setter<? super Long> setter) {
+            super(parser, option, setter);
+        }
+
+        @Override
+        public int parseArguments(Parameters params) throws CmdLineException {
+            final long value;
+            try {
+                value = parse(params.getParameter(0));
+            } catch (IllegalArgumentException ex) {
+                throw new CmdLineException(owner, "unable to parse size", ex);
+            }
+
+            setter.addValue(value);
+            return 1;  // 1 argument consumed.
+        }
+
+        @Override
+        public String getDefaultMetaVariable() {
+            return "size";
+        }
+
+        @Override
+        protected String print(Long v) {
+            return render(v);
+        }
+    };
+}

--- a/lib/src/test/java/com/groupon/lex/metrics/lib/BytesParserTest.java
+++ b/lib/src/test/java/com/groupon/lex/metrics/lib/BytesParserTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016, Ariane van der Steldt
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics.lib;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class BytesParserTest {
+    @Test
+    public void parseTest() {
+        assertEquals(0L, BytesParser.parse("0"));
+        assertEquals(17L, BytesParser.parse("17"));
+
+        assertEquals(4L << 10, BytesParser.parse("4k"));
+        assertEquals(4L << 10, BytesParser.parse("4K"));
+
+        assertEquals(16L << 20, BytesParser.parse("16m"));
+        assertEquals(16L << 20, BytesParser.parse("16M"));
+
+        assertEquals(5L << 30, BytesParser.parse("5g"));
+        assertEquals(5L << 30, BytesParser.parse("5G"));
+
+        assertEquals(764L << 40, BytesParser.parse("764t"));
+        assertEquals(764L << 40, BytesParser.parse("764T"));
+
+        assertEquals(2048L << 50, BytesParser.parse("2048p"));
+        assertEquals(2048L << 50, BytesParser.parse("2048P"));
+
+        assertEquals(3L << 60, BytesParser.parse("3e"));
+        assertEquals(3L << 60, BytesParser.parse("3E"));
+    }
+
+    @Test
+    public void renderTest() {
+        assertEquals("0", BytesParser.render(0));
+        assertEquals("17", BytesParser.render(17));
+        assertEquals("1025", BytesParser.render(1025));
+
+        assertEquals("4k", BytesParser.render(4L << 10));
+
+        assertEquals("16M", BytesParser.render(16L << 20));
+
+        assertEquals("389G", BytesParser.render(389L << 30));
+
+        assertEquals("2020T", BytesParser.render(2020L << 40));
+
+        assertEquals("5P", BytesParser.render(5L << 50));
+
+        assertEquals("6E", BytesParser.render(6L << 60));
+    }
+}

--- a/rhist_server/src/main/java/com/groupon/monsoon/remote/history/server/RhistMain.java
+++ b/rhist_server/src/main/java/com/groupon/monsoon/remote/history/server/RhistMain.java
@@ -32,6 +32,7 @@
 package com.groupon.monsoon.remote.history.server;
 
 import com.groupon.lex.metrics.history.xdr.DirCollectHistory;
+import com.groupon.lex.metrics.lib.BytesParser.BytesParserOptionHandler;
 import com.groupon.monsoon.remote.history.CollectHistoryServer;
 import java.io.IOException;
 import java.nio.file.FileSystems;
@@ -59,6 +60,9 @@ public class RhistMain {
 
     @Option(name="-p", usage="list on given port")
     private int port = CollectHistoryServer.DEFAULT_PORT;
+
+    @Option(name="-s", usage="limit history size", handler = BytesParserOptionHandler.class)
+    private long size = 16L << 30;
 
     @Argument(metaVar="/path/to/history/dir", usage="path: which dir contains the history files", index=0)
     private String dir;
@@ -101,7 +105,7 @@ public class RhistMain {
     }
 
     public void run() throws IOException, OncRpcException {
-        CollectHistoryServer server = new CollectHistoryServer(new DirCollectHistory(path_));
+        final CollectHistoryServer server = new CollectHistoryServer(new DirCollectHistory(path_, size));
 
         OncRpcUdpServerTransport rpcUdp = new OncRpcUdpServerTransport(server, null, port, server.info, 32768);
         rpcUdp.setCharacterEncoding("UTF-8");


### PR DESCRIPTION
Adds ``-s`` argument to history server.

Example:

    java -jar monsoon-rhist-server.jar -s 128G /path/to/history

will clamp the history dir size to 128G.