### PR TITLE
compression

### DIFF
--- a/history/pom.xml
+++ b/history/pom.xml
@@ -49,9 +49,9 @@
             <version>3.0.3</version>
         </dependency>
         <dependency>
-            <groupId>org.anarres.lzo</groupId>
-            <artifactId>lzo-core</artifactId>
-            <version>1.0.5</version>
+            <groupId>org.iq80.snappy</groupId>
+            <artifactId>snappy</artifactId>
+            <version>0.4</version>
         </dependency>
     </dependencies>
 

--- a/history/pom.xml
+++ b/history/pom.xml
@@ -49,6 +49,11 @@
             <version>3.0.3</version>
         </dependency>
         <dependency>
+            <groupId>org.anarres.lzo</groupId>
+            <artifactId>lzo-core</artifactId>
+            <version>1.0.5</version>
+        </dependency>
+        <dependency>
             <groupId>org.iq80.snappy</groupId>
             <artifactId>snappy</artifactId>
             <version>0.4</version>

--- a/history/pom.xml
+++ b/history/pom.xml
@@ -48,6 +48,11 @@
             <artifactId>trove4j</artifactId>
             <version>3.0.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.anarres.lzo</groupId>
+            <artifactId>lzo-core</artifactId>
+            <version>1.0.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
@@ -15,7 +15,7 @@ public enum Compression {
     GZIP(header_flags.GZIP, in -> new GzipReader(in), out -> new GzipWriter(out)),
     SNAPPY(header_flags.SNAPPY, in -> new SnappyReader(in), out -> new SnappyWriter(out));
 
-    public static final Compression DEFAULT = SNAPPY;
+    public static final Compression DEFAULT = GZIP;
 
     public final int compressionFlag;
     private final WrapReaderFunctor reader;

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
@@ -18,8 +18,8 @@ public enum Compression {
     SNAPPY(header_flags.SNAPPY, in -> new SnappyReader(in), out -> new SnappyWriter(out)),
     LZO(header_flags.LZO_1X1, in -> new LzoReader(in), out -> new LzoWriter(out));
 
-    public static final Compression DEFAULT_APPEND = SNAPPY;
-    public static final Compression DEFAULT_OPTIMIZED = LZO;
+    public static final Compression DEFAULT_APPEND = GZIP;
+    public static final Compression DEFAULT_OPTIMIZED = GZIP;
 
     public final int compressionFlag;
     private final WrapReaderFunctor reader;

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
@@ -1,0 +1,54 @@
+package com.groupon.lex.metrics.history.v2;
+
+import com.groupon.lex.metrics.history.v2.xdr.header_flags;
+import com.groupon.lex.metrics.history.xdr.support.reader.FileReader;
+import com.groupon.lex.metrics.history.xdr.support.reader.GzipReader;
+import com.groupon.lex.metrics.history.xdr.support.reader.LzoReader;
+import com.groupon.lex.metrics.history.xdr.support.writer.FileWriter;
+import com.groupon.lex.metrics.history.xdr.support.writer.GzipWriter;
+import com.groupon.lex.metrics.history.xdr.support.writer.LzoWriter;
+import java.io.IOException;
+import static java.util.Objects.requireNonNull;
+
+public enum Compression {
+    NONE(0, in -> in, out -> out),
+    GZIP(header_flags.GZIP, in -> new GzipReader(in), out -> new GzipWriter(out)),
+    LZO(header_flags.LZO, in -> new LzoReader(in), out -> new LzoWriter(out));
+
+    public static final Compression DEFAULT = LZO;
+
+    public final int compressionFlag;
+    private final WrapReaderFunctor reader;
+    private final WrapWriterFunctor writer;
+
+    private Compression(int compressionFlag, WrapReaderFunctor reader, WrapWriterFunctor writer) {
+        this.compressionFlag = compressionFlag;
+        this.reader = requireNonNull(reader);
+        this.writer = requireNonNull(writer);
+    }
+
+    public FileReader wrap(FileReader reader) throws IOException {
+        return this.reader.wrap(reader);
+    }
+
+    public FileWriter wrap(FileWriter writer) throws IOException {
+        return this.writer.wrap(writer);
+    }
+
+    private static interface WrapReaderFunctor {
+        public FileReader wrap(FileReader in) throws IOException;
+    }
+
+    private static interface WrapWriterFunctor {
+        public FileWriter wrap(FileWriter out) throws IOException;
+    }
+
+    public static Compression fromFlags(int flags) {
+        int cmpFlag = flags & header_flags.COMPRESSION_MASK;
+        for (Compression cmprs : values()) {
+            if (cmprs.compressionFlag == cmpFlag)
+                return cmprs;
+        }
+        throw new IllegalArgumentException("unrecognized compression 0x" + Integer.toHexString(cmpFlag));
+    }
+}

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
@@ -3,9 +3,11 @@ package com.groupon.lex.metrics.history.v2;
 import com.groupon.lex.metrics.history.v2.xdr.header_flags;
 import com.groupon.lex.metrics.history.xdr.support.reader.FileReader;
 import com.groupon.lex.metrics.history.xdr.support.reader.GzipReader;
+import com.groupon.lex.metrics.history.xdr.support.reader.LzoReader;
 import com.groupon.lex.metrics.history.xdr.support.reader.SnappyReader;
 import com.groupon.lex.metrics.history.xdr.support.writer.FileWriter;
 import com.groupon.lex.metrics.history.xdr.support.writer.GzipWriter;
+import com.groupon.lex.metrics.history.xdr.support.writer.LzoWriter;
 import com.groupon.lex.metrics.history.xdr.support.writer.SnappyWriter;
 import java.io.IOException;
 import static java.util.Objects.requireNonNull;
@@ -13,9 +15,11 @@ import static java.util.Objects.requireNonNull;
 public enum Compression {
     NONE(0, in -> in, out -> out),
     GZIP(header_flags.GZIP, in -> new GzipReader(in), out -> new GzipWriter(out)),
-    SNAPPY(header_flags.SNAPPY, in -> new SnappyReader(in), out -> new SnappyWriter(out));
+    SNAPPY(header_flags.SNAPPY, in -> new SnappyReader(in), out -> new SnappyWriter(out)),
+    LZO(header_flags.LZO_1X1, in -> new LzoReader(in), out -> new LzoWriter(out));
 
-    public static final Compression DEFAULT = GZIP;
+    public static final Compression DEFAULT_APPEND = SNAPPY;
+    public static final Compression DEFAULT_OPTIMIZED = LZO;
 
     public final int compressionFlag;
     private final WrapReaderFunctor reader;

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
@@ -3,19 +3,19 @@ package com.groupon.lex.metrics.history.v2;
 import com.groupon.lex.metrics.history.v2.xdr.header_flags;
 import com.groupon.lex.metrics.history.xdr.support.reader.FileReader;
 import com.groupon.lex.metrics.history.xdr.support.reader.GzipReader;
-import com.groupon.lex.metrics.history.xdr.support.reader.LzoReader;
+import com.groupon.lex.metrics.history.xdr.support.reader.SnappyReader;
 import com.groupon.lex.metrics.history.xdr.support.writer.FileWriter;
 import com.groupon.lex.metrics.history.xdr.support.writer.GzipWriter;
-import com.groupon.lex.metrics.history.xdr.support.writer.LzoWriter;
+import com.groupon.lex.metrics.history.xdr.support.writer.SnappyWriter;
 import java.io.IOException;
 import static java.util.Objects.requireNonNull;
 
 public enum Compression {
     NONE(0, in -> in, out -> out),
     GZIP(header_flags.GZIP, in -> new GzipReader(in), out -> new GzipWriter(out)),
-    LZO(header_flags.LZO, in -> new LzoReader(in), out -> new LzoWriter(out));
+    SNAPPY(header_flags.SNAPPY, in -> new SnappyReader(in), out -> new SnappyWriter(out));
 
-    public static final Compression DEFAULT = LZO;
+    public static final Compression DEFAULT = SNAPPY;
 
     public final int compressionFlag;
     private final WrapReaderFunctor reader;

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/list/RWListFile.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/list/RWListFile.java
@@ -32,6 +32,7 @@
 package com.groupon.lex.metrics.history.v2.list;
 
 import com.groupon.lex.metrics.history.TSData;
+import com.groupon.lex.metrics.history.v2.Compression;
 import com.groupon.lex.metrics.history.v2.xdr.ToXdr;
 import static com.groupon.lex.metrics.history.v2.xdr.Util.HDR_3_LEN;
 import static com.groupon.lex.metrics.history.v2.xdr.Util.fixSequence;
@@ -103,11 +104,15 @@ public class RWListFile implements TSData {
             state = new ReadOnlyState(file, hdr);
     }
 
-    public static RWListFile newFile(@NonNull GCCloseable<FileChannel> file, boolean compress) throws IOException {
+    public static RWListFile newFile(@NonNull GCCloseable<FileChannel> file) throws IOException {
+        return newFile(file, Compression.DEFAULT);
+    }
+
+    public static RWListFile newFile(@NonNull GCCloseable<FileChannel> file, Compression compression) throws IOException {
         final tsfile_header hdr = new tsfile_header();
         hdr.last = hdr.first = ToXdr.timestamp(new DateTime(DateTimeZone.UTC));
         hdr.file_size = MIME_HEADER_LEN + HDR_3_LEN + CRC_LEN;
-        hdr.flags = (header_flags.SORTED | header_flags.KIND_LIST | (compress ? header_flags.GZIP : 0));
+        hdr.flags = (header_flags.SORTED | header_flags.KIND_LIST | compression.compressionFlag);
         hdr.reserved = 0;
         hdr.fdt = ToXdr.filePos(new FilePos(0, 0));
 

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/list/RWListFile.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/list/RWListFile.java
@@ -105,7 +105,7 @@ public class RWListFile implements TSData {
     }
 
     public static RWListFile newFile(@NonNull GCCloseable<FileChannel> file) throws IOException {
-        return newFile(file, Compression.DEFAULT);
+        return newFile(file, Compression.DEFAULT_APPEND);
     }
 
     public static RWListFile newFile(@NonNull GCCloseable<FileChannel> file, Compression compression) throws IOException {

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/list/ReadonlyTSDataHeader.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/list/ReadonlyTSDataHeader.java
@@ -31,6 +31,7 @@
  */
 package com.groupon.lex.metrics.history.v2.list;
 
+import com.groupon.lex.metrics.history.v2.Compression;
 import com.groupon.lex.metrics.history.v2.xdr.FromXdr;
 import com.groupon.lex.metrics.history.v2.xdr.dictionary_delta;
 import com.groupon.lex.metrics.history.v2.xdr.record_array;
@@ -68,17 +69,17 @@ public class ReadonlyTSDataHeader {
         return Optional.ofNullable(previousTSData);
     }
 
-    public SegmentReader<Optional<dictionary_delta>> dictionaryDecoder(GCCloseable<FileChannel> file, boolean compressed) {
+    public SegmentReader<Optional<dictionary_delta>> dictionaryDecoder(GCCloseable<FileChannel> file, Compression compression) {
         if (dictionary == null) {
             LOG.log(Level.FINER, "no dictionary present");
             return SegmentReader.of(Optional.empty());
         }
         LOG.log(Level.FINER, "dictionary present at {0}", dictionary);
-        return new FileChannelSegmentReader<>(dictionary_delta::new, file, dictionary, compressed)
+        return new FileChannelSegmentReader<>(dictionary_delta::new, file, dictionary, compression)
                 .map(Optional::of);
     }
 
-    public SegmentReader<record_array> recordsDecoder(GCCloseable<FileChannel> file, boolean compressed) {
-        return new FileChannelSegmentReader<>(record_array::new, file, records, compressed);
+    public SegmentReader<record_array> recordsDecoder(GCCloseable<FileChannel> file, Compression compression) {
+        return new FileChannelSegmentReader<>(record_array::new, file, records, compression);
     }
 }

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/ReadonlyTableFile.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/ReadonlyTableFile.java
@@ -32,6 +32,7 @@
 package com.groupon.lex.metrics.history.v2.tables;
 
 import com.groupon.lex.metrics.history.TSData;
+import com.groupon.lex.metrics.history.v2.Compression;
 import com.groupon.lex.metrics.history.v2.xdr.FromXdr;
 import static com.groupon.lex.metrics.history.v2.xdr.Util.HDR_3_LEN;
 import com.groupon.lex.metrics.history.v2.xdr.file_data_tables;
@@ -145,13 +146,24 @@ public class ReadonlyTableFile implements TSData {
     }
 
     @Override
-    public short getMajor() { return Const.version_major(version); }
+    public short getMajor() {
+        return Const.version_major(version);
+    }
+
     @Override
-    public short getMinor() { return Const.version_minor(version); }
+    public short getMinor() {
+        return Const.version_minor(version);
+    }
+
     @Override
-    public boolean canAddSingleRecord() { return false; }
+    public boolean canAddSingleRecord() {
+        return false;
+    }
+
     @Override
-    public boolean isOptimized() { return true; }
+    public boolean isOptimized() {
+        return true;
+    }
 
     @Override
     public Optional<GCCloseable<FileChannel>> getFileChannel() {
@@ -184,7 +196,7 @@ public class ReadonlyTableFile implements TSData {
         if ((hdr.flags & header_flags.KIND_MASK) != header_flags.KIND_TABLES)
             throw new IllegalArgumentException("Not a file in table encoding");
 
-        final boolean gzipped = ((hdr.flags & header_flags.GZIP) == header_flags.GZIP);
+        final Compression compression = Compression.fromFlags(hdr.flags);
         if ((hdr.flags & header_flags.DISTINCT) != header_flags.DISTINCT)
             throw new IllegalArgumentException("Bad TableFile: marked as containing duplicate timestamps");
         if ((hdr.flags & header_flags.SORTED) != header_flags.SORTED)
@@ -192,7 +204,7 @@ public class ReadonlyTableFile implements TSData {
         begin = FromXdr.timestamp(hdr.first);
         end = FromXdr.timestamp(hdr.last);
 
-        segmentFactory = new FileChannelSegmentReader.Factory(file, gzipped);
+        segmentFactory = new FileChannelSegmentReader.Factory(file, compression);
         final FilePos bodyPos = FromXdr.filePos(hdr.fdt);
 
         body = segmentFactory.get(file_data_tables::new, bodyPos)

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/ToXdrTables.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/ToXdrTables.java
@@ -157,7 +157,7 @@ public class ToXdrTables implements Closeable {
                 throw new IOException("encoding error", ex);
             }
         } finally {
-            LOG.log(Level.INFO, "adding timeseries {0} took {1} msec", new Object[]{tsc.getTimestamp(), System.currentTimeMillis() - ts0});
+            LOG.log(Level.FINE, "adding timeseries {0} took {1} msec", new Object[]{tsc.getTimestamp(), System.currentTimeMillis() - ts0});
         }
     }
 

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/TSDataFileChain.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/TSDataFileChain.java
@@ -514,7 +514,7 @@ public class TSDataFileChain implements TSData {
 
         final FileUtil.NamedFileChannel newFile = FileUtil.createNewFile(dir_, prefix, ".optimized");
         try {
-            try (final ToXdrTables tables = new ToXdrTables(newFile.getFileChannel(), Compression.DEFAULT)) {
+            try (final ToXdrTables tables = new ToXdrTables(newFile.getFileChannel(), Compression.DEFAULT_OPTIMIZED)) {
                 tables.addAll(tsdata);
             }
 

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/FileUtil.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/FileUtil.java
@@ -31,6 +31,7 @@
  */
 package com.groupon.lex.metrics.history.xdr.support;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.OpenOption;
@@ -49,15 +50,28 @@ import lombok.Getter;
  */
 public class FileUtil {
     private static final SecureRandom RANDOM = new SecureRandom();
+    public static final Path TMPDIR = new File(System.getProperty("java.io.tmpdir")).toPath();
 
-    /** Create a temporary file that will be removed when it is closed. */
+    /**
+     * Create a temporary file that will be removed when it is closed.
+     */
     public static FileChannel createTempFile(Path dir, String prefix, String suffix) throws IOException {
-        return createNewFileImpl(dir, prefix, suffix, new OpenOption[]{ READ, WRITE, CREATE_NEW, DELETE_ON_CLOSE }).getFileChannel();
+        return createNewFileImpl(dir, prefix, suffix, new OpenOption[]{READ, WRITE, CREATE_NEW, DELETE_ON_CLOSE}).getFileChannel();
     }
 
-    /** Creates a new file and opens it for reading and writing. */
+    /**
+     * Create a temporary file that will be removed when it is closed, in the
+     * tmpdir location.
+     */
+    public static FileChannel createTempFile(String prefix, String suffix) throws IOException {
+        return createTempFile(TMPDIR, prefix, suffix);
+    }
+
+    /**
+     * Creates a new file and opens it for reading and writing.
+     */
     public static NamedFileChannel createNewFile(Path dir, String prefix, String suffix) throws IOException {
-        return createNewFileImpl(dir, prefix, suffix, new OpenOption[]{ READ, WRITE, CREATE_NEW });
+        return createNewFileImpl(dir, prefix, suffix, new OpenOption[]{READ, WRITE, CREATE_NEW});
     }
 
     private static NamedFileChannel createNewFileImpl(Path dir, String prefix, String suffix, OpenOption openOptions[]) throws IOException {

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/TmpFile.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/TmpFile.java
@@ -1,0 +1,114 @@
+package com.groupon.lex.metrics.history.xdr.support;
+
+import com.groupon.lex.metrics.history.v2.Compression;
+import com.groupon.lex.metrics.history.xdr.support.reader.FileChannelReader;
+import com.groupon.lex.metrics.history.xdr.support.reader.XdrDecodingFileReader;
+import com.groupon.lex.metrics.history.xdr.support.writer.FileChannelWriter;
+import com.groupon.lex.metrics.history.xdr.support.writer.XdrEncodingFileWriter;
+import com.groupon.lex.metrics.lib.Any2;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Supplier;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.acplt.oncrpc.OncRpcException;
+import org.acplt.oncrpc.XdrAble;
+
+public class TmpFile<T extends XdrAble> implements Closeable {
+    private final FileChannel fd;
+    private final Compression compression;
+    private Any2<XdrDecodingFileReader, XdrEncodingFileWriter> fileIO;
+    private int count = 0;
+
+    private TmpFile(FileChannel fd, Compression compression) throws IOException {
+        this.fd = fd;
+        this.compression = compression;
+        this.fileIO = Any2.right(new XdrEncodingFileWriter(compression.wrap(new FileChannelWriter(fd, 0)), 64 * 1024));
+    }
+
+    public TmpFile(Path dir, Compression compression) throws IOException {
+        this(FileUtil.createTempFile(dir, "monsoon", ".tmp"), compression);
+    }
+
+    public TmpFile(Compression compression) throws IOException {
+        this(FileUtil.createTempFile("monsoon", ".tmp"), compression);
+    }
+
+    @Override
+    public void close() throws IOException {
+        Exception exc = null;  // We capture reader/writer errors, but don't throw them.
+        try {
+            AutoCloseable readerWriter = fileIO.mapCombine(x -> x, x -> x);
+            if (readerWriter != null)
+                readerWriter.close();
+        } catch (Exception ex) {
+            exc = ex;
+        }
+
+        try {
+            fd.close();
+        } catch (IOException ex) {
+            ex.addSuppressed(exc);  // We do add reader/writer exception to the IOException, as they're useful in debugging.
+            throw ex;
+        }
+    }
+
+    public void add(@NonNull T v) throws OncRpcException, IOException {
+        final XdrEncodingFileWriter xdr = fileIO.getRight().orElseThrow(() -> new IllegalStateException("cannot write: we switched to reading"));
+        if (count == 0)
+            xdr.beginEncoding();
+        v.xdrEncode(xdr);
+        ++count;
+    }
+
+    public int size() {
+        return count;
+    }
+
+    public Iterator<T> iterator(@NonNull Supplier<T> valueSupplier) throws IOException, OncRpcException {
+        if (!fileIO.getLeft().isPresent()) {
+            fileIO.getRight().orElseThrow(IllegalStateException::new).endEncoding();
+            fileIO.getRight().orElseThrow(IllegalStateException::new).close();
+            fileIO = Any2.left(new XdrDecodingFileReader(compression.wrap(new FileChannelReader(fd, 0)), 64 * 1024));
+        }
+
+        final XdrDecodingFileReader xdr = fileIO.getLeft().orElseThrow(() -> new IllegalStateException("cannot read: expected reader"));
+        xdr.beginDecoding();
+        return new IteratorImpl(xdr, valueSupplier, count);
+    }
+
+    @RequiredArgsConstructor
+    private class IteratorImpl implements Iterator<T> {
+        private final XdrDecodingFileReader xdr;
+        private final Supplier<T> valueSupplier;
+        private final int maxCount;
+        private int count = 0;
+
+        @Override
+        public boolean hasNext() {
+            return count < maxCount;
+        }
+
+        @Override
+        public T next() {
+            try {
+                if (count == maxCount)
+                    throw new NoSuchElementException("cannot read: at end of file");
+                T v = valueSupplier.get();
+                v.xdrDecode(xdr);
+                ++count;
+                if (count == maxCount) {
+                    xdr.endDecoding();
+                    xdr.close();
+                }
+                return v;
+            } catch (IOException | OncRpcException ex) {
+                throw new DecodingException("cannot read: decoding failed", ex);
+            }
+        }
+    }
+}

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/AbstractInputStreamReader.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/AbstractInputStreamReader.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics.history.xdr.support.reader;
+
+import com.groupon.lex.metrics.history.xdr.support.IOLengthVerificationFailed;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import static java.util.Objects.requireNonNull;
+import lombok.NonNull;
+
+public class AbstractInputStreamReader implements FileReader {
+    private final InputStream in;
+    private final boolean validateAllRead;
+
+    protected AbstractInputStreamReader(InputStream in, boolean validateAllRead) throws IOException {
+        this.in = requireNonNull(in);
+        this.validateAllRead = validateAllRead;
+    }
+
+    protected AbstractInputStreamReader(InputStream in) throws IOException {
+        this(in, true);
+    }
+
+    @Override
+    public int read(ByteBuffer data) throws IOException {
+        final int rlen;
+        if (data.hasArray()) {
+            rlen = in.read(data.array(), data.arrayOffset() + data.position(), data.remaining());
+            if (rlen > 0)
+                data.position(data.position() + rlen);
+        } else {
+            byte tmp[] = new byte[data.remaining()];
+            rlen = in.read(tmp);
+            if (rlen > 0)
+                data.put(tmp, 0, rlen);
+        }
+
+        if (rlen == -1)
+            throw new EOFException("no more data");
+        return rlen;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (validateAllRead) {
+            if (in.read() != -1)
+                throw new IOLengthVerificationFailed(0, 0);
+        }
+        in.close();
+    }
+
+    @Override
+    public ByteBuffer allocateByteBuffer(int size) {
+        return ByteBuffer.allocate(size);
+    }
+
+    protected static InputStream newAdapter(FileReader in) {
+        return new Adapter(in);
+    }
+
+    private static class Adapter extends InputStream {
+        private final FileReader in;
+
+        public Adapter(@NonNull FileReader in) {
+            this.in = in;
+        }
+
+        @Override
+        public int read() throws IOException {
+            byte tmp[] = new byte[1];
+            int rlen = read(tmp);
+            if (rlen == -1)
+                return -1;
+            return (int) tmp[0] & 0xff;
+        }
+
+        @Override
+        public int read(byte b[], int off, int len) throws IOException {
+            if (len == 0)
+                return 0;
+
+            int rlen;
+            try {
+                rlen = in.read(ByteBuffer.wrap(b, off, len));
+            } catch (EOFException ex) {
+                rlen = -1;
+            }
+            return rlen;
+        }
+
+        @Override
+        public void close() throws IOException {
+            in.close();
+        }
+    }
+}

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/GzipReader.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/GzipReader.java
@@ -31,89 +31,15 @@
  */
 package com.groupon.lex.metrics.history.xdr.support.reader;
 
-import com.groupon.lex.metrics.history.xdr.support.IOLengthVerificationFailed;
-import java.io.EOFException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.util.zip.GZIPInputStream;
-import lombok.NonNull;
 
-public class GzipReader implements FileReader {
-    private final GZIPInputStream gzip;
-    private final boolean validateAllRead;
-
+public class GzipReader extends AbstractInputStreamReader {
     public GzipReader(FileReader in, boolean validateAllRead) throws IOException {
-        this.gzip = new GZIPInputStream(new GzAdapter(in));
-        this.validateAllRead = validateAllRead;
+        super(new GZIPInputStream(newAdapter(in)), validateAllRead);
     }
 
     public GzipReader(FileReader in) throws IOException {
-        this(in, true);
-    }
-
-    @Override
-    public int read(ByteBuffer data) throws IOException {
-        final int rlen;
-        if (data.hasArray()) {
-            rlen = gzip.read(data.array(), data.arrayOffset() + data.position(), data.remaining());
-            if (rlen > 0) data.position(data.position() + rlen);
-        } else {
-            byte tmp[] = new byte[data.remaining()];
-            rlen = gzip.read(tmp);
-            if (rlen > 0) data.put(tmp, 0, rlen);
-        }
-
-        if (rlen == -1)
-            throw new EOFException("no more data (gzip)");
-        return rlen;
-    }
-
-    @Override
-    public void close() throws IOException {
-        if (validateAllRead) {
-            if (gzip.read() != -1)
-                throw new IOLengthVerificationFailed(0, 0);
-        }
-        gzip.close();
-    }
-
-    @Override
-    public ByteBuffer allocateByteBuffer(int size) {
-        return ByteBuffer.allocate(size);
-    }
-
-    private static class GzAdapter extends InputStream {
-        private final FileReader in;
-
-        public GzAdapter(@NonNull FileReader in) {
-            this.in = in;
-        }
-
-        @Override
-        public int read() throws IOException {
-            byte tmp[] = new byte[1];
-            int rlen = read(tmp);
-            if (rlen == -1) return -1;
-            return (int)tmp[0] & 0xff;
-        }
-
-        @Override
-        public int read(byte b[], int off, int len) throws IOException {
-            if (len == 0) return 0;
-
-            int rlen;
-            try {
-                rlen = in.read(ByteBuffer.wrap(b, off, len));
-            } catch (EOFException ex) {
-                rlen = -1;
-            }
-            return rlen;
-        }
-
-        @Override
-        public void close() throws IOException {
-            in.close();
-        }
+        super(new GZIPInputStream(newAdapter(in)));
     }
 }

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/LzoReader.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/LzoReader.java
@@ -1,0 +1,98 @@
+package com.groupon.lex.metrics.history.xdr.support.reader;
+
+import com.groupon.lex.metrics.history.xdr.support.IOLengthVerificationFailed;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import lombok.NonNull;
+import org.anarres.lzo.LzoAlgorithm;
+import org.anarres.lzo.LzoDecompressor;
+import org.anarres.lzo.LzoInputStream;
+import org.anarres.lzo.LzoLibrary;
+
+public class LzoReader implements FileReader {
+    public static final LzoAlgorithm ALGORITHM = LzoAlgorithm.LZO1X;
+    private final LzoInputStream lzo;
+    private final boolean validateAllRead;
+
+    public LzoReader(FileReader in, boolean validateAllRead) {
+        LzoDecompressor decompressor = LzoLibrary.getInstance().newDecompressor(ALGORITHM, null);
+        this.lzo = new LzoInputStream(new Adapter(in), decompressor);
+        this.lzo.setInputBufferSize(64 * 1024);
+        this.validateAllRead = validateAllRead;
+    }
+
+    public LzoReader(FileReader in) {
+        this(in, true);
+    }
+
+    @Override
+    public int read(ByteBuffer data) throws IOException {
+        final int rlen;
+        if (data.hasArray()) {
+            rlen = lzo.read(data.array(), data.arrayOffset() + data.position(), data.remaining());
+            if (rlen > 0)
+                data.position(data.position() + rlen);
+        } else {
+            byte tmp[] = new byte[data.remaining()];
+            rlen = lzo.read(tmp);
+            if (rlen > 0)
+                data.put(tmp, 0, rlen);
+        }
+
+        if (rlen == -1)
+            throw new EOFException("no more data (gzip)");
+        return rlen;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (validateAllRead) {
+            if (lzo.read() != -1)
+                throw new IOLengthVerificationFailed(0, 0);
+        }
+        lzo.close();
+    }
+
+    @Override
+    public ByteBuffer allocateByteBuffer(int size) {
+        return ByteBuffer.allocate(size);
+    }
+
+    private static class Adapter extends InputStream {
+        private final FileReader in;
+
+        public Adapter(@NonNull FileReader in) {
+            this.in = in;
+        }
+
+        @Override
+        public int read() throws IOException {
+            byte tmp[] = new byte[1];
+            int rlen = read(tmp);
+            if (rlen == -1)
+                return -1;
+            return (int) tmp[0] & 0xff;
+        }
+
+        @Override
+        public int read(byte b[], int off, int len) throws IOException {
+            if (len == 0)
+                return 0;
+
+            int rlen;
+            try {
+                rlen = in.read(ByteBuffer.wrap(b, off, len));
+            } catch (EOFException ex) {
+                rlen = -1;
+            }
+            return rlen;
+        }
+
+        @Override
+        public void close() throws IOException {
+            in.close();
+        }
+    }
+}

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/LzoReader.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/LzoReader.java
@@ -1,0 +1,27 @@
+package com.groupon.lex.metrics.history.xdr.support.reader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.anarres.lzo.LzoAlgorithm;
+import org.anarres.lzo.LzoDecompressor;
+import org.anarres.lzo.LzoInputStream;
+import org.anarres.lzo.LzoLibrary;
+
+public class LzoReader extends AbstractInputStreamReader {
+    public static final LzoAlgorithm ALGORITHM = LzoAlgorithm.LZO1X;
+
+    public LzoReader(FileReader in, boolean validateAllRead) throws IOException {
+        super(createLzoInputStream(newAdapter(in)), validateAllRead);
+    }
+
+    public LzoReader(FileReader in) throws IOException {
+        super(createLzoInputStream(newAdapter(in)));
+    }
+
+    private static InputStream createLzoInputStream(InputStream adapter) {
+        LzoDecompressor decompressor = LzoLibrary.getInstance().newDecompressor(ALGORITHM, null);
+        LzoInputStream lzo = new LzoInputStream(adapter, decompressor);
+        lzo.setInputBufferSize(64 * 1024);
+        return lzo;
+    }
+}

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/SizeVerifyingReader.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/SizeVerifyingReader.java
@@ -32,6 +32,7 @@
 package com.groupon.lex.metrics.history.xdr.support.reader;
 
 import com.groupon.lex.metrics.history.xdr.support.IOLengthVerificationFailed;
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import lombok.RequiredArgsConstructor;
@@ -45,11 +46,11 @@ public class SizeVerifyingReader implements FileReader {
     @Override
     public int read(ByteBuffer data) throws IOException {
         if (read == expected)
-            throw new IOLengthVerificationFailed(expected, read + data.remaining());
+            throw new EOFException("no more data");
         if (data.remaining() > expected - read)
-            data.limit(data.position() + (int)(expected - read));
+            data.limit(data.position() + (int) (expected - read));
 
-        assert(data.remaining() <= expected - read);
+        assert (data.remaining() <= expected - read);
         final int rlen = in.read(data);
         read += rlen;
         return rlen;
@@ -57,7 +58,8 @@ public class SizeVerifyingReader implements FileReader {
 
     @Override
     public void close() throws IOException {
-        if (read != expected) throw new IOLengthVerificationFailed(expected, read);
+        if (read != expected)
+            throw new IOLengthVerificationFailed(expected, read);
         in.close();
     }
 

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/SnappyReader.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/SnappyReader.java
@@ -1,92 +1,14 @@
 package com.groupon.lex.metrics.history.xdr.support.reader;
 
-import com.groupon.lex.metrics.history.xdr.support.IOLengthVerificationFailed;
-import java.io.EOFException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
-import lombok.NonNull;
 import org.iq80.snappy.SnappyFramedInputStream;
 
-public class SnappyReader implements FileReader {
-    private final SnappyFramedInputStream snappy;
-    private final boolean validateAllRead;
-
+public class SnappyReader extends AbstractInputStreamReader {
     public SnappyReader(FileReader in, boolean validateAllRead) throws IOException {
-        this.snappy = new SnappyFramedInputStream(new Adapter(in), true);
-        this.validateAllRead = validateAllRead;
+        super(new SnappyFramedInputStream(newAdapter(in), true), validateAllRead);
     }
 
     public SnappyReader(FileReader in) throws IOException {
-        this(in, true);
-    }
-
-    @Override
-    public int read(ByteBuffer data) throws IOException {
-        final int rlen;
-        if (data.hasArray()) {
-            rlen = snappy.read(data.array(), data.arrayOffset() + data.position(), data.remaining());
-            if (rlen > 0)
-                data.position(data.position() + rlen);
-        } else {
-            byte tmp[] = new byte[data.remaining()];
-            rlen = snappy.read(tmp);
-            if (rlen > 0)
-                data.put(tmp, 0, rlen);
-        }
-
-        if (rlen == -1)
-            throw new EOFException("no more data (gzip)");
-        return rlen;
-    }
-
-    @Override
-    public void close() throws IOException {
-        if (validateAllRead) {
-            if (snappy.read() != -1)
-                throw new IOLengthVerificationFailed(0, 0);
-        }
-        snappy.close();
-    }
-
-    @Override
-    public ByteBuffer allocateByteBuffer(int size) {
-        return ByteBuffer.allocate(size);
-    }
-
-    private static class Adapter extends InputStream {
-        private final FileReader in;
-
-        public Adapter(@NonNull FileReader in) {
-            this.in = in;
-        }
-
-        @Override
-        public int read() throws IOException {
-            byte tmp[] = new byte[1];
-            int rlen = read(tmp);
-            if (rlen == -1)
-                return -1;
-            return (int) tmp[0] & 0xff;
-        }
-
-        @Override
-        public int read(byte b[], int off, int len) throws IOException {
-            if (len == 0)
-                return 0;
-
-            int rlen;
-            try {
-                rlen = in.read(ByteBuffer.wrap(b, off, len));
-            } catch (EOFException ex) {
-                rlen = -1;
-            }
-            return rlen;
-        }
-
-        @Override
-        public void close() throws IOException {
-            in.close();
-        }
+        super(new SnappyFramedInputStream(newAdapter(in), true));
     }
 }

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/AbstractOutputStreamWriter.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/AbstractOutputStreamWriter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2016, Groupon, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.groupon.lex.metrics.history.xdr.support.writer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import static java.lang.Math.min;
+import java.nio.ByteBuffer;
+import static java.util.Objects.requireNonNull;
+import lombok.NonNull;
+
+public class AbstractOutputStreamWriter implements FileWriter {
+    private final OutputStream out;
+
+    protected AbstractOutputStreamWriter(OutputStream out) throws IOException {
+        this.out = requireNonNull(out);
+    }
+
+    @Override
+    public int write(ByteBuffer data) throws IOException {
+        if (data.hasArray()) {
+            final int wlen = data.remaining();
+            out.write(data.array(), data.arrayOffset() + data.position(), wlen);
+            data.position(data.limit());
+            return wlen;
+        } else {
+            int written = 0;
+            byte buf[] = new byte[512];
+            while (data.hasRemaining()) {
+                final int buflen = min(data.remaining(), buf.length);
+                data.get(buf, 0, buflen);
+                out.write(buf, 0, buflen);
+                written += buflen;
+            }
+            return written;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+    }
+
+    @Override
+    public ByteBuffer allocateByteBuffer(int size) {
+        return ByteBuffer.allocate(size);
+    }
+
+    protected static OutputStream newAdapter(FileWriter out) {
+        return new Adapter(out);
+    }
+
+    private static class Adapter extends OutputStream {
+        private final FileWriter out;
+
+        public Adapter(@NonNull FileWriter out) {
+            this.out = out;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            byte tmp[] = new byte[1];
+            tmp[0] = (byte) (b & 0xff);
+            write(tmp);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            ByteBuffer buf = ByteBuffer.wrap(b, off, len);
+            while (buf.hasRemaining())
+                out.write(buf);
+        }
+
+        @Override
+        public void close() throws IOException {
+            out.close();
+        }
+    }
+}

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/GzipWriter.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/GzipWriter.java
@@ -32,73 +32,11 @@
 package com.groupon.lex.metrics.history.xdr.support.writer;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.ByteBuffer;
 import java.util.zip.GZIPOutputStream;
 import lombok.NonNull;
-import static java.lang.Math.min;
 
-public class GzipWriter implements FileWriter {
-    private final GZIPOutputStream gzip;
-
+public class GzipWriter extends AbstractOutputStreamWriter {
     public GzipWriter(@NonNull FileWriter out) throws IOException {
-        gzip = new GZIPOutputStream(new GzAdapter(out), 65536);
-    }
-
-    @Override
-    public int write(ByteBuffer data) throws IOException {
-        if (data.hasArray()) {
-            final int wlen = data.remaining();
-            gzip.write(data.array(), data.arrayOffset() + data.position(), wlen);
-            data.position(data.limit());
-            return wlen;
-        } else {
-            int written = 0;
-            byte buf[] = new byte[512];
-            while (data.hasRemaining()) {
-                final int buflen = min(data.remaining(), buf.length);
-                data.get(buf, 0, buflen);
-                gzip.write(buf, 0, buflen);
-                written += buflen;
-            }
-            return written;
-        }
-    }
-
-    @Override
-    public void close() throws IOException {
-        gzip.close();
-    }
-
-    @Override
-    public ByteBuffer allocateByteBuffer(int size) {
-        return ByteBuffer.allocate(size);
-    }
-
-    private static class GzAdapter extends OutputStream {
-        private final FileWriter out;
-
-        public GzAdapter(@NonNull FileWriter out) {
-            this.out = out;
-        }
-
-        @Override
-        public void write(int b) throws IOException {
-            byte tmp[] = new byte[1];
-            tmp[0] = (byte)(b & 0xff);
-            write(tmp);
-        }
-
-        @Override
-        public void write(byte[] b, int off, int len) throws IOException {
-            ByteBuffer buf = ByteBuffer.wrap(b, off, len);
-            while (buf.hasRemaining())
-                out.write(buf);
-        }
-
-        @Override
-        public void close() throws IOException {
-            out.close();
-        }
+        super(new GZIPOutputStream(newAdapter(out), 65536));
     }
 }

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/LzoWriter.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/LzoWriter.java
@@ -1,0 +1,23 @@
+package com.groupon.lex.metrics.history.xdr.support.writer;
+
+import com.groupon.lex.metrics.history.xdr.support.reader.LzoReader;
+import java.io.IOException;
+import java.io.OutputStream;
+import org.anarres.lzo.LzoAlgorithm;
+import org.anarres.lzo.LzoCompressor;
+import org.anarres.lzo.LzoLibrary;
+import org.anarres.lzo.LzoOutputStream;
+
+public class LzoWriter extends AbstractOutputStreamWriter {
+    public static final LzoAlgorithm ALGORITHM = LzoReader.ALGORITHM;
+
+    public LzoWriter(FileWriter out) throws IOException {
+        super(createLzoOutputStream(newAdapter(out)));
+    }
+
+    private static OutputStream createLzoOutputStream(OutputStream adapter) {
+        LzoCompressor compressor = LzoLibrary.getInstance().newCompressor(ALGORITHM, null);
+        LzoOutputStream lzo = new LzoOutputStream(adapter, compressor, 64 * 1024);
+        return lzo;
+    }
+}

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/LzoWriter.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/LzoWriter.java
@@ -1,0 +1,89 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.groupon.lex.metrics.history.xdr.support.writer;
+
+import com.groupon.lex.metrics.history.xdr.support.reader.LzoReader;
+import java.io.IOException;
+import java.io.OutputStream;
+import static java.lang.Math.min;
+import java.nio.ByteBuffer;
+import lombok.NonNull;
+import org.anarres.lzo.LzoAlgorithm;
+import org.anarres.lzo.LzoCompressor;
+import org.anarres.lzo.LzoLibrary;
+import org.anarres.lzo.LzoOutputStream;
+
+/**
+ *
+ * @author ariane
+ */
+public class LzoWriter implements FileWriter {
+    public static final LzoAlgorithm ALGORITHM = LzoReader.ALGORITHM;
+    private final LzoOutputStream lzo;
+
+    public LzoWriter(@NonNull FileWriter out) throws IOException {
+        LzoAlgorithm algorithm = LzoAlgorithm.LZO1X;
+        LzoCompressor compressor = LzoLibrary.getInstance().newCompressor(algorithm, null);
+        this.lzo = new LzoOutputStream(new Adapter(out), compressor, 64 * 1024);
+    }
+
+    @Override
+    public int write(ByteBuffer data) throws IOException {
+        if (data.hasArray()) {
+            final int wlen = data.remaining();
+            lzo.write(data.array(), data.arrayOffset() + data.position(), wlen);
+            data.position(data.limit());
+            return wlen;
+        } else {
+            int written = 0;
+            byte buf[] = new byte[512];
+            while (data.hasRemaining()) {
+                final int buflen = min(data.remaining(), buf.length);
+                data.get(buf, 0, buflen);
+                lzo.write(buf, 0, buflen);
+                written += buflen;
+            }
+            return written;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        lzo.close();
+    }
+
+    @Override
+    public ByteBuffer allocateByteBuffer(int size) {
+        return ByteBuffer.allocate(size);
+    }
+
+    private static class Adapter extends OutputStream {
+        private final FileWriter out;
+
+        public Adapter(@NonNull FileWriter out) {
+            this.out = out;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            byte tmp[] = new byte[1];
+            tmp[0] = (byte) (b & 0xff);
+            write(tmp);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            ByteBuffer buf = ByteBuffer.wrap(b, off, len);
+            while (buf.hasRemaining())
+                out.write(buf);
+        }
+
+        @Override
+        public void close() throws IOException {
+            out.close();
+        }
+    }
+}

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/LzoWriter.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/LzoWriter.java
@@ -25,8 +25,7 @@ public class LzoWriter implements FileWriter {
     private final LzoOutputStream lzo;
 
     public LzoWriter(@NonNull FileWriter out) throws IOException {
-        LzoAlgorithm algorithm = LzoAlgorithm.LZO1X;
-        LzoCompressor compressor = LzoLibrary.getInstance().newCompressor(algorithm, null);
+        LzoCompressor compressor = LzoLibrary.getInstance().newCompressor(ALGORITHM, null);
         this.lzo = new LzoOutputStream(new Adapter(out), compressor, 64 * 1024);
     }
 

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/SnappyWriter.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/SnappyWriter.java
@@ -6,9 +6,6 @@
 package com.groupon.lex.metrics.history.xdr.support.writer;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import static java.lang.Math.min;
-import java.nio.ByteBuffer;
 import lombok.NonNull;
 import org.iq80.snappy.SnappyFramedOutputStream;
 
@@ -16,67 +13,8 @@ import org.iq80.snappy.SnappyFramedOutputStream;
  *
  * @author ariane
  */
-public class SnappyWriter implements FileWriter {
-    private final SnappyFramedOutputStream snappy;
-
+public class SnappyWriter extends AbstractOutputStreamWriter {
     public SnappyWriter(@NonNull FileWriter out) throws IOException {
-        this.snappy = new SnappyFramedOutputStream(new Adapter(out));
-    }
-
-    @Override
-    public int write(ByteBuffer data) throws IOException {
-        if (data.hasArray()) {
-            final int wlen = data.remaining();
-            snappy.write(data.array(), data.arrayOffset() + data.position(), wlen);
-            data.position(data.limit());
-            return wlen;
-        } else {
-            int written = 0;
-            byte buf[] = new byte[512];
-            while (data.hasRemaining()) {
-                final int buflen = min(data.remaining(), buf.length);
-                data.get(buf, 0, buflen);
-                snappy.write(buf, 0, buflen);
-                written += buflen;
-            }
-            return written;
-        }
-    }
-
-    @Override
-    public void close() throws IOException {
-        snappy.close();
-    }
-
-    @Override
-    public ByteBuffer allocateByteBuffer(int size) {
-        return ByteBuffer.allocate(size);
-    }
-
-    private static class Adapter extends OutputStream {
-        private final FileWriter out;
-
-        public Adapter(@NonNull FileWriter out) {
-            this.out = out;
-        }
-
-        @Override
-        public void write(int b) throws IOException {
-            byte tmp[] = new byte[1];
-            tmp[0] = (byte) (b & 0xff);
-            write(tmp);
-        }
-
-        @Override
-        public void write(byte[] b, int off, int len) throws IOException {
-            ByteBuffer buf = ByteBuffer.wrap(b, off, len);
-            while (buf.hasRemaining())
-                out.write(buf);
-        }
-
-        @Override
-        public void close() throws IOException {
-            out.close();
-        }
+        super(new SnappyFramedOutputStream(newAdapter(out)));
     }
 }

--- a/history/src/main/xdr/tsdata_2_0.x
+++ b/history/src/main/xdr/tsdata_2_0.x
@@ -49,7 +49,7 @@ enum header_flags {
     /* indicate if opaque segments are compressed (gzip) */
     COMPRESSION_MASK = 0x3f000000,
     GZIP = 0x20000000,
-    LZO = 0x30000000,
+    LZO = 0x30000000,  /* LZO 1X-1 */
 
     /* indicate if all records are sorted by timestamp */
     SORTED = 0x40000000,

--- a/history/src/main/xdr/tsdata_2_0.x
+++ b/history/src/main/xdr/tsdata_2_0.x
@@ -48,8 +48,9 @@ enum header_flags {
 
     /* indicate if opaque segments are compressed (gzip) */
     COMPRESSION_MASK = 0x3f000000,
-    GZIP = 0x20000000,
-    SNAPPY = 0x30000000,
+    LZO_1X1          = 0x10000000,
+    GZIP             = 0x20000000,
+    SNAPPY           = 0x30000000,
 
     /* indicate if all records are sorted by timestamp */
     SORTED = 0x40000000,

--- a/history/src/main/xdr/tsdata_2_0.x
+++ b/history/src/main/xdr/tsdata_2_0.x
@@ -49,7 +49,7 @@ enum header_flags {
     /* indicate if opaque segments are compressed (gzip) */
     COMPRESSION_MASK = 0x3f000000,
     GZIP = 0x20000000,
-    LZO = 0x30000000,  /* LZO 1X-1 */
+    SNAPPY = 0x30000000,
 
     /* indicate if all records are sorted by timestamp */
     SORTED = 0x40000000,

--- a/history/src/main/xdr/tsdata_2_0.x
+++ b/history/src/main/xdr/tsdata_2_0.x
@@ -47,7 +47,9 @@ enum header_flags {
     KIND_TABLES = 0x1,
 
     /* indicate if opaque segments are compressed (gzip) */
+    COMPRESSION_MASK = 0x3f000000,
     GZIP = 0x20000000,
+    LZO = 0x30000000,
 
     /* indicate if all records are sorted by timestamp */
     SORTED = 0x40000000,

--- a/history/src/test/java/com/groupon/lex/metrics/history/v2/list/FileListFileSupport.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/v2/list/FileListFileSupport.java
@@ -47,7 +47,7 @@ import java.util.Collection;
 public class FileListFileSupport implements FileSupport.Writer {
     @Override
     public void create_file(TSDataVersionDispatch.Releaseable<FileChannel> fd, Collection<? extends TimeSeriesCollection> tsdata, boolean compress) throws IOException {
-        RWListFile listFile = RWListFile.newFile(new GCCloseable<>(fd.release()), compress ? Compression.DEFAULT : Compression.NONE);
+        RWListFile listFile = RWListFile.newFile(new GCCloseable<>(fd.release()), compress ? Compression.DEFAULT_APPEND : Compression.NONE);
         tsdata.forEach(listFile::add);
     }
 

--- a/history/src/test/java/com/groupon/lex/metrics/history/v2/list/FileListFileSupport.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/v2/list/FileListFileSupport.java
@@ -32,6 +32,7 @@
 package com.groupon.lex.metrics.history.v2.list;
 
 import com.groupon.lex.metrics.history.TSDataVersionDispatch;
+import com.groupon.lex.metrics.history.v2.Compression;
 import com.groupon.lex.metrics.history.xdr.support.FileSupport;
 import com.groupon.lex.metrics.lib.GCCloseable;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
@@ -46,13 +47,18 @@ import java.util.Collection;
 public class FileListFileSupport implements FileSupport.Writer {
     @Override
     public void create_file(TSDataVersionDispatch.Releaseable<FileChannel> fd, Collection<? extends TimeSeriesCollection> tsdata, boolean compress) throws IOException {
-        RWListFile listFile = RWListFile.newFile(new GCCloseable<>(fd.release()), true);
+        RWListFile listFile = RWListFile.newFile(new GCCloseable<>(fd.release()), compress ? Compression.DEFAULT : Compression.NONE);
         tsdata.forEach(listFile::add);
     }
 
     @Override
-    public short getMajor() { return (short)2; }
+    public short getMajor() {
+        return (short) 2;
+    }
+
     @Override
-    public short getMinor() { return (short)0; }
+    public short getMinor() {
+        return (short) 0;
+    }
 
 }

--- a/history/src/test/java/com/groupon/lex/metrics/history/v2/tables/FileTableFileSupport.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/v2/tables/FileTableFileSupport.java
@@ -38,7 +38,6 @@ import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.util.Collection;
-import org.acplt.oncrpc.OncRpcException;
 
 /**
  *
@@ -47,12 +46,8 @@ import org.acplt.oncrpc.OncRpcException;
 public class FileTableFileSupport implements FileSupport.Writer {
     @Override
     public void create_file(TSDataVersionDispatch.Releaseable<FileChannel> fd, Collection<? extends TimeSeriesCollection> tsdata, boolean compress) throws IOException {
-        try {
-            ToXdrTables newTables = new ToXdrTables();
+        try (ToXdrTables newTables = new ToXdrTables(fd.get(), compress ? Compression.DEFAULT : Compression.NONE)) {
             newTables.addAll(tsdata);
-            newTables.write(fd.get(), compress ? Compression.DEFAULT : Compression.NONE);
-        } catch (OncRpcException ex) {
-            throw new IOException(ex);
         }
     }
 

--- a/history/src/test/java/com/groupon/lex/metrics/history/v2/tables/FileTableFileSupport.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/v2/tables/FileTableFileSupport.java
@@ -46,7 +46,7 @@ import java.util.Collection;
 public class FileTableFileSupport implements FileSupport.Writer {
     @Override
     public void create_file(TSDataVersionDispatch.Releaseable<FileChannel> fd, Collection<? extends TimeSeriesCollection> tsdata, boolean compress) throws IOException {
-        try (ToXdrTables newTables = new ToXdrTables(fd.get(), compress ? Compression.DEFAULT : Compression.NONE)) {
+        try (ToXdrTables newTables = new ToXdrTables(fd.get(), compress ? Compression.DEFAULT_OPTIMIZED : Compression.NONE)) {
             newTables.addAll(tsdata);
         }
     }

--- a/history/src/test/java/com/groupon/lex/metrics/history/v2/tables/FileTableFileSupport.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/v2/tables/FileTableFileSupport.java
@@ -32,6 +32,7 @@
 package com.groupon.lex.metrics.history.v2.tables;
 
 import com.groupon.lex.metrics.history.TSDataVersionDispatch;
+import com.groupon.lex.metrics.history.v2.Compression;
 import com.groupon.lex.metrics.history.xdr.support.FileSupport;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
 import java.io.IOException;
@@ -49,16 +50,24 @@ public class FileTableFileSupport implements FileSupport.Writer {
         try {
             ToXdrTables newTables = new ToXdrTables();
             newTables.addAll(tsdata);
-            newTables.write(fd.get(), compress);
+            newTables.write(fd.get(), compress ? Compression.DEFAULT : Compression.NONE);
         } catch (OncRpcException ex) {
             throw new IOException(ex);
         }
     }
 
     @Override
-    public short getMajor() { return (short)2; }
+    public short getMajor() {
+        return (short) 2;
+    }
+
     @Override
-    public short getMinor() { return (short)0; }
+    public short getMinor() {
+        return (short) 0;
+    }
+
     @Override
-    public boolean isEmptyAllowed() { return false; }
+    public boolean isEmptyAllowed() {
+        return false;
+    }
 }

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/TSDataTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/TSDataTest.java
@@ -61,21 +61,21 @@ public class TSDataTest {
     private Path tmpdir, tmpfile;
     private final DateTime NOW = new DateTime(DateTimeZone.UTC);
 
-    @Parameterized.Parameters
+    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> parameters() {
         return Arrays.asList(
-                new Object[]{new FileSupport(new FileSupport0(), false)},
-                new Object[]{new FileSupport(new FileSupport1(), false)},
-                new Object[]{new FileSupport(new FileTableFileSupport(), false)},
-                new Object[]{new FileSupport(new FileListFileSupport(), false)},
-                new Object[]{new FileSupport(new FileSupport0(), true)},
-                new Object[]{new FileSupport(new FileSupport1(), true)},
-                new Object[]{new FileSupport(new FileTableFileSupport(), true)},
-                new Object[]{new FileSupport(new FileListFileSupport(), true)}
+                new Object[]{"v0.1 uncompressed", new FileSupport(new FileSupport0(), false)},
+                new Object[]{"v1.0 uncompressed", new FileSupport(new FileSupport1(), false)},
+                new Object[]{"v2.0 uncompressed table", new FileSupport(new FileTableFileSupport(), false)},
+                new Object[]{"v2.0 uncompressed list", new FileSupport(new FileListFileSupport(), false)},
+                new Object[]{"v0.1 compressed", new FileSupport(new FileSupport0(), true)},
+                new Object[]{"v1.0 compressed", new FileSupport(new FileSupport1(), true)},
+                new Object[]{"v2.0 compressed table", new FileSupport(new FileTableFileSupport(), true)},
+                new Object[]{"v2.0 compressed list", new FileSupport(new FileListFileSupport(), true)}
         );
     }
 
-    public TSDataTest(FileSupport file_support) {
+    public TSDataTest(String name, FileSupport file_support) {
         this.file_support = file_support;
     }
 
@@ -112,7 +112,7 @@ public class TSDataTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void cannot_add() throws Exception {
-        final List<TimeSeriesCollection> tsdata = create_tsdata_(10).collect(Collectors.toList());
+        final List<TimeSeriesCollection> tsdata = create_tsdata_(2).collect(Collectors.toList());
         file_support.create_file(tmpfile, tsdata);
 
         final TSData fd = TSData.readonly(tmpfile);
@@ -121,7 +121,7 @@ public class TSDataTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void cannot_add_all() throws Exception {
-        final List<TimeSeriesCollection> tsdata = create_tsdata_(10).collect(Collectors.toList());
+        final List<TimeSeriesCollection> tsdata = create_tsdata_(2).collect(Collectors.toList());
         file_support.create_file(tmpfile, tsdata);
 
         final TSData fd = TSData.readonly(tmpfile);
@@ -158,7 +158,7 @@ public class TSDataTest {
 
     @Test
     public void to_array() throws Exception {
-        final List<TimeSeriesCollection> tsdata = create_tsdata_(10).collect(Collectors.toList());
+        final List<TimeSeriesCollection> tsdata = create_tsdata_(2).collect(Collectors.toList());
         file_support.create_file(tmpfile, tsdata);
 
         final TSData fd = TSData.readonly(tmpfile);
@@ -168,7 +168,7 @@ public class TSDataTest {
 
     @Test
     public void to_array_with_array_constructor() throws Exception {
-        final List<TimeSeriesCollection> tsdata = create_tsdata_(10).collect(Collectors.toList());
+        final List<TimeSeriesCollection> tsdata = create_tsdata_(2).collect(Collectors.toList());
         file_support.create_file(tmpfile, tsdata);
 
         final TSData fd = TSData.readonly(tmpfile);
@@ -178,13 +178,13 @@ public class TSDataTest {
 
     @Test
     public void contains() throws Exception {
-        final List<TimeSeriesCollection> tsdata = create_tsdata_(10).collect(Collectors.toList());
-        file_support.create_file(tmpfile, tsdata.subList(0, 9));
+        final List<TimeSeriesCollection> tsdata = create_tsdata_(3).collect(Collectors.toList());
+        file_support.create_file(tmpfile, tsdata.subList(0, 2));
 
         final TSData fd = TSData.readonly(tmpfile);
 
-        assertTrue(fd.contains(tsdata.get(8)));
-        assertFalse(fd.contains(tsdata.get(9)));
+        assertTrue(fd.contains(tsdata.get(1)));
+        assertFalse(fd.contains(tsdata.get(2)));
         assertFalse(fd.contains(new Object()));
     }
 
@@ -258,7 +258,7 @@ public class TSDataTest {
 
     @Test
     public void add_all_none_existing() {
-        final List<TimeSeriesCollection> tsdata = create_tsdata_(10).collect(Collectors.toList());
+        final List<TimeSeriesCollection> tsdata = create_tsdata_(4).collect(Collectors.toList());
         final Set<TimeSeriesCollection> result = new HashSet<>();
         final TSData impl = new TSDataMock() {
             @Override
@@ -272,7 +272,7 @@ public class TSDataTest {
 
     @Test
     public void add_all_all_existing() {
-        final List<TimeSeriesCollection> tsdata = create_tsdata_(10).collect(Collectors.toList());
+        final List<TimeSeriesCollection> tsdata = create_tsdata_(4).collect(Collectors.toList());
         final Set<TimeSeriesCollection> result = new HashSet<>(tsdata);
         final TSData impl = new TSDataMock() {
             @Override

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/reader/Crc32VerifyingFileReaderTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/reader/Crc32VerifyingFileReaderTest.java
@@ -32,6 +32,7 @@
 package com.groupon.lex.metrics.history.xdr.support.reader;
 
 import com.groupon.lex.metrics.history.xdr.support.IOLengthVerificationFailed;
+import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -59,12 +60,12 @@ public class Crc32VerifyingFileReaderTest {
     }
 
     public byte[] setupWithCrc(byte padValue, boolean correctCrc, int padLen, int roundUp) throws Exception {
-        assert(padLen == 0 ||
-                (padLen > 0 && padLen < roundUp));  // Padding is used to reach multiple of roundUp.
+        assert (padLen == 0
+                || (padLen > 0 && padLen < roundUp));  // Padding is used to reach multiple of roundUp.
         byte[] data;
         data = new byte[roundUp * (8 * 1024 + 1) - padLen];
         for (int i = 0; i < data.length; ++i)
-            data[i] = (byte)(i ^ (i % 97));
+            data[i] = (byte) (i ^ (i % 97));
 
         CRC32 crc32 = new CRC32();
         crc32.update(ByteBuffer.wrap(data));
@@ -76,7 +77,8 @@ public class Crc32VerifyingFileReaderTest {
 
             buf = ByteBuffer.allocate(padLen);
             buf.order(ByteOrder.BIG_ENDIAN);
-            while (buf.hasRemaining()) buf.put(padValue);
+            while (buf.hasRemaining())
+                buf.put(padValue);
             buf.flip();
             crc32.update(buf.duplicate());
             while (buf.hasRemaining())
@@ -84,7 +86,7 @@ public class Crc32VerifyingFileReaderTest {
 
             buf = ByteBuffer.allocate(4);
             buf.order(ByteOrder.BIG_ENDIAN);
-            buf.putInt((int)(correctCrc ? crc32.getValue() : ~crc32.getValue()));
+            buf.putInt((int) (correctCrc ? crc32.getValue() : ~crc32.getValue()));
             buf.flip();
             while (buf.hasRemaining())
                 fd.write(buf);
@@ -110,52 +112,52 @@ public class Crc32VerifyingFileReaderTest {
 
     @Test
     public void read_pad0_valid() throws Exception {
-        readValid((byte)0, true, 0, 0);
+        readValid((byte) 0, true, 0, 0);
     }
 
     @Test
     public void read_pad0_valid_roundUp() throws Exception {
-        readValid((byte)0, true, 0, 7);  // Should still work with weird roundup.
+        readValid((byte) 0, true, 0, 7);  // Should still work with weird roundup.
     }
 
     @Test
     public void read_pad3_valid_roundUp() throws Exception {
-        readValid((byte)0, true, 3, 7);
+        readValid((byte) 0, true, 3, 7);
     }
 
     @Test
     public void read_pad6_valid_roundUp() throws Exception {
-        readValid((byte)0, true, 6, 7);  // Should still work with weird roundup.
+        readValid((byte) 0, true, 6, 7);  // Should still work with weird roundup.
     }
 
     @Test(expected = Crc32VerifyingFileReader.IOCrcMismatchException.class)
     public void read_pad0_invalid() throws Exception {
-        readValid((byte)0, false, 0, 0);
+        readValid((byte) 0, false, 0, 0);
     }
 
     @Test(expected = Crc32VerifyingFileReader.IOCrcMismatchException.class)
     public void read_pad0_invalid_roundUp() throws Exception {
-        readValid((byte)0, false, 3, 4);
+        readValid((byte) 0, false, 3, 4);
     }
 
     @Test(expected = Crc32VerifyingFileReader.IOCrcMismatchException.class)
     public void read_pad3_invalid_roundUp() throws Exception {
-        readValid((byte)0, false, 3, 4);
+        readValid((byte) 0, false, 3, 4);
     }
 
     @Test(expected = Crc32VerifyingFileReader.IOPaddingException.class)
     public void read_badPad_valid() throws Exception {
-        readValid((byte)7, false, 3, 4);
+        readValid((byte) 7, false, 3, 4);
     }
 
     @Test(expected = IOException.class)
     public void read_badPad_invalid() throws Exception {
-        readValid((byte)7, false, 3, 4);
+        readValid((byte) 7, false, 3, 4);
     }
 
     @Test(expected = IOLengthVerificationFailed.class)
     public void readTooLittle() throws Exception {
-        byte expected[] = setupWithCrc((byte)0, true, 0, 4);
+        byte expected[] = setupWithCrc((byte) 0, true, 0, 4);
         byte output[] = new byte[expected.length - 1024];
 
         try (FileChannel fd = FileChannel.open(file, StandardOpenOption.READ)) {
@@ -167,9 +169,9 @@ public class Crc32VerifyingFileReaderTest {
         }
     }
 
-    @Test(expected = IOLengthVerificationFailed.class)
+    @Test(expected = EOFException.class)
     public void readTooMuch() throws Exception {
-        byte expected[] = setupWithCrc((byte)0, true, 0, 4);
+        byte expected[] = setupWithCrc((byte) 0, true, 0, 4);
         byte output[] = new byte[expected.length + 1024];
 
         try (FileChannel fd = FileChannel.open(file, StandardOpenOption.READ)) {

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/reader/FileChannelSegmentReaderTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/reader/FileChannelSegmentReaderTest.java
@@ -75,12 +75,12 @@ public class FileChannelSegmentReaderTest {
 
     @Test
     public void readCompressed() throws Exception {
-        FilePos pos = create(Compression.DEFAULT);
+        FilePos pos = create(Compression.DEFAULT_APPEND);
 
         GCCloseable<FileChannel> fd = new GCCloseable<>(FileChannel.open(file, StandardOpenOption.READ));
-        FileChannelSegmentReader<XdrAbleImpl> reader = new FileChannelSegmentReader<>(XdrAbleImpl::new, fd, pos, Compression.DEFAULT);
+        FileChannelSegmentReader<XdrAbleImpl> reader = new FileChannelSegmentReader<>(XdrAbleImpl::new, fd, pos, Compression.DEFAULT_APPEND);
 
-        assertEquals(Compression.DEFAULT, reader.getCompression());
+        assertEquals(Compression.DEFAULT_APPEND, reader.getCompression());
         assertEquals(expected, reader.decode());
     }
 
@@ -98,8 +98,8 @@ public class FileChannelSegmentReaderTest {
     @Test
     public void factoryCompressed() throws Exception {
         GCCloseable<FileChannel> fd = new GCCloseable<>(FileChannel.open(file, StandardOpenOption.READ));
-        FileChannelSegmentReader.Factory factory = new FileChannelSegmentReader.Factory(fd, Compression.DEFAULT);
-        FilePos pos = create(Compression.DEFAULT);
+        FileChannelSegmentReader.Factory factory = new FileChannelSegmentReader.Factory(fd, Compression.DEFAULT_APPEND);
+        FilePos pos = create(Compression.DEFAULT_APPEND);
 
         assertEquals(expected, factory.get(XdrAbleImpl::new, pos).decode());
     }

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/reader/SizeVerifyingReaderTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/reader/SizeVerifyingReaderTest.java
@@ -32,6 +32,7 @@
 package com.groupon.lex.metrics.history.xdr.support.reader;
 
 import com.groupon.lex.metrics.history.xdr.support.IOLengthVerificationFailed;
+import java.io.EOFException;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -57,7 +58,7 @@ public class SizeVerifyingReaderTest {
 
         data = new byte[1024 * 1024];
         for (int i = 0; i < data.length; ++i)
-            data[i] = (byte)(i ^ (i % 97));
+            data[i] = (byte) (i ^ (i % 97));
 
         try (FileChannel fd = FileChannel.open(file, StandardOpenOption.WRITE)) {
             for (int i = 0; i < 2; ++i) {
@@ -83,7 +84,7 @@ public class SizeVerifyingReaderTest {
         assertArrayEquals(data, output);
     }
 
-    @Test(expected = IOLengthVerificationFailed.class)
+    @Test(expected = EOFException.class)
     public void readTooMuch() throws Exception {
         byte output[] = new byte[data.length + 1024];
 

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/writer/AbstractSegmentWriterTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/writer/AbstractSegmentWriterTest.java
@@ -31,6 +31,7 @@
  */
 package com.groupon.lex.metrics.history.xdr.support.writer;
 
+import com.groupon.lex.metrics.history.v2.Compression;
 import com.groupon.lex.metrics.history.xdr.support.FilePos;
 import com.groupon.lex.metrics.history.xdr.support.reader.FileChannelSegmentReader;
 import com.groupon.lex.metrics.lib.GCCloseable;
@@ -70,17 +71,17 @@ public class AbstractSegmentWriterTest {
     @Test
     public void write() throws Exception {
         GCCloseable<FileChannel> fd = new GCCloseable<>(FileChannel.open(file.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE));
-        FilePos pos = writeable.write(new AbstractSegmentWriter.Writer(fd.get(), 0, false), new long[]{ 9 });
+        FilePos pos = writeable.write(new AbstractSegmentWriter.Writer(fd.get(), 0, Compression.NONE), new long[]{9});
 
-        assertEquals(xdrAble, new FileChannelSegmentReader<>(XdrAbleImpl::new, fd, pos, false).decode());
+        assertEquals(xdrAble, new FileChannelSegmentReader<>(XdrAbleImpl::new, fd, pos, Compression.NONE).decode());
     }
 
     @Test
     public void writeCompressed() throws Exception {
         GCCloseable<FileChannel> fd = new GCCloseable<>(FileChannel.open(file.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE));
-        FilePos pos = writeable.write(new AbstractSegmentWriter.Writer(fd.get(), 0, true), new long[]{ 9 });
+        FilePos pos = writeable.write(new AbstractSegmentWriter.Writer(fd.get(), 0, Compression.DEFAULT), new long[]{9});
 
-        assertEquals(xdrAble, new FileChannelSegmentReader<>(XdrAbleImpl::new, fd, pos, true).decode());
+        assertEquals(xdrAble, new FileChannelSegmentReader<>(XdrAbleImpl::new, fd, pos, Compression.DEFAULT).decode());
     }
 
     @Data

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/writer/AbstractSegmentWriterTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/writer/AbstractSegmentWriterTest.java
@@ -79,9 +79,9 @@ public class AbstractSegmentWriterTest {
     @Test
     public void writeCompressed() throws Exception {
         GCCloseable<FileChannel> fd = new GCCloseable<>(FileChannel.open(file.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE));
-        FilePos pos = writeable.write(new AbstractSegmentWriter.Writer(fd.get(), 0, Compression.DEFAULT), new long[]{9});
+        FilePos pos = writeable.write(new AbstractSegmentWriter.Writer(fd.get(), 0, Compression.DEFAULT_APPEND), new long[]{9});
 
-        assertEquals(xdrAble, new FileChannelSegmentReader<>(XdrAbleImpl::new, fd, pos, Compression.DEFAULT).decode());
+        assertEquals(xdrAble, new FileChannelSegmentReader<>(XdrAbleImpl::new, fd, pos, Compression.DEFAULT_APPEND).decode());
     }
 
     @Data


### PR DESCRIPTION
Introduce two new compression formats:
- LZO-1X
- Snappy

Gzip is kept the default, as it compresses better and there's hardly any gain from using a faster algorithm.

Also change table format creation to use temporary files, reducing memory pressure and eliminating the need to hold all collections in memory.  Conversion now runs happily in 512 MB, but still takes a long time.