### PR TITLE
Parallellize table file creation.

### DIFF
--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/ToXdrTables.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/ToXdrTables.java
@@ -54,6 +54,7 @@ import com.groupon.lex.metrics.history.v2.xdr.timestamp_msec;
 import com.groupon.lex.metrics.history.v2.xdr.tsfile_header;
 import static com.groupon.lex.metrics.history.xdr.Const.MIME_HEADER_LEN;
 import static com.groupon.lex.metrics.history.xdr.Const.writeMimeHeader;
+import com.groupon.lex.metrics.history.xdr.support.FJPTaskExecutor;
 import com.groupon.lex.metrics.history.xdr.support.FilePos;
 import com.groupon.lex.metrics.history.xdr.support.TmpFile;
 import com.groupon.lex.metrics.history.xdr.support.writer.AbstractSegmentWriter.Writer;
@@ -151,8 +152,8 @@ public class ToXdrTables implements Closeable {
                 }
 
                 timestamps.add(timestamp);
-                for (TimeSeriesValue tsv : tsc.getTSValues())
-                    processGroup(timestamp, tsv);
+                new FJPTaskExecutor<>(tsc.getTSValues(), tsv -> processGroup(timestamp, tsv))
+                        .join();
             } catch (OncRpcException ex) {
                 throw new IOException("encoding error", ex);
             }

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/ToXdrTables.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/ToXdrTables.java
@@ -108,7 +108,7 @@ public class ToXdrTables implements Closeable {
     private static final Logger LOG = Logger.getLogger(ToXdrTables.class.getName());
     private static final int HDR_SPACE = MIME_HEADER_LEN + HDR_3_LEN + CRC_LEN;
     private static final int MAX_BLOCK_RECORDS = 10000;
-    private static final Compression TMPFILE_COMPRESSION = Compression.NONE;
+    private static final Compression TMPFILE_COMPRESSION = Compression.SNAPPY;
     @NonNull
     private final FileChannel out;
     @NonNull

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/FJPTaskExecutor.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/FJPTaskExecutor.java
@@ -1,0 +1,121 @@
+package com.groupon.lex.metrics.history.xdr.support;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A task executor that runs tasks on a ForkJoinPool. The executor ensures not
+ * too many tasks are scheduled at once, so it won't starve other jobs running
+ * on the same pool.
+ *
+ * @author ariane
+ */
+public class FJPTaskExecutor<T> {
+    public static final int DEFAULT_CONCURRENCY = Runtime.getRuntime().availableProcessors();
+    private final BlockingQueue<Task> done;
+    private final Iterator<T> pending;
+    private final JobFunction<T> jobFn;
+
+    public FJPTaskExecutor(@NonNull Collection<T> datums, @NonNull JobFunction<T> jobFn, int concurrency) {
+        this.done = new ArrayBlockingQueue<>(Integer.max(1, concurrency));
+        this.pending = datums.iterator();
+        this.jobFn = jobFn;
+    }
+
+    public FJPTaskExecutor(@NonNull Collection<T> datums, @NonNull JobFunction<T> jobFn) {
+        this(datums, jobFn, DEFAULT_CONCURRENCY);
+    }
+
+    public void join() {
+        int queued = 0;
+        for (int i = done.remainingCapacity(); i > 0 && pending.hasNext(); --i) {
+            new Task(pending.next()).fork();
+            ++queued;
+        }
+
+        while (queued > 0) {
+            fjpDone().join();
+            --queued;
+
+            if (pending.hasNext()) {
+                new Task(pending.next()).fork();
+                ++queued;
+            }
+        }
+    }
+
+    public static interface JobFunction<T> {
+        public void accept(T v) throws Exception;
+    }
+
+    private class FJPDone implements ForkJoinPool.ManagedBlocker {
+        private Task doneTask = null;
+
+        public Task get() {
+            return doneTask;
+        }
+
+        @Override
+        public boolean block() throws InterruptedException {
+            if (doneTask == null)
+                doneTask = done.take();
+            return doneTask != null;
+        }
+
+        @Override
+        public boolean isReleasable() {
+            if (doneTask == null)
+                doneTask = done.poll();
+            return doneTask != null;
+        }
+    }
+
+    private Task fjpDone() {
+        FJPDone blocker = new FJPDone();
+        for (;;) {
+            try {
+                ForkJoinPool.managedBlock(blocker);
+                return blocker.get();
+            } catch (InterruptedException ex) {
+                /* SKIP */
+            }
+        }
+    }
+
+    @RequiredArgsConstructor
+    private class Task extends ForkJoinTask<T> {
+        private final T argument;
+        private T rawResult;
+
+        @Override
+        public T getRawResult() {
+            return rawResult;
+        }
+
+        @Override
+        protected void setRawResult(T value) {
+            rawResult = value;
+        }
+
+        @Override
+        protected boolean exec() {
+            try {
+                jobFn.accept(argument);
+                rawResult = argument;
+                return true;
+            } catch (Error | RuntimeException ex) {
+                throw ex;
+            } catch (Exception ex) {
+                throw new RuntimeException("task execution failed", ex);
+            } finally {
+                done.add(this);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Makes creating table files a lot faster.
Also, compression on the temp files seems to help with speed (reduced IO load?), so enable that.