### PR TITLE
High compression

### DIFF
--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
@@ -19,7 +19,7 @@ public enum Compression {
     LZO(header_flags.LZO_1X1, in -> new LzoReader(in), (out, hc) -> new LzoWriter(out, hc));
 
     public static final Compression DEFAULT_APPEND = GZIP;
-    public static final Compression DEFAULT_OPTIMIZED = GZIP;
+    public static final Compression DEFAULT_OPTIMIZED = LZO;
 
     public final int compressionFlag;
     private final WrapReaderFunctor reader;

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
@@ -13,10 +13,10 @@ import java.io.IOException;
 import static java.util.Objects.requireNonNull;
 
 public enum Compression {
-    NONE(0, in -> in, out -> out),
-    GZIP(header_flags.GZIP, in -> new GzipReader(in), out -> new GzipWriter(out)),
-    SNAPPY(header_flags.SNAPPY, in -> new SnappyReader(in), out -> new SnappyWriter(out)),
-    LZO(header_flags.LZO_1X1, in -> new LzoReader(in), out -> new LzoWriter(out));
+    NONE(0, in -> in, (out, hc) -> out),
+    GZIP(header_flags.GZIP, in -> new GzipReader(in), (out, hc) -> new GzipWriter(out)),
+    SNAPPY(header_flags.SNAPPY, in -> new SnappyReader(in), (out, hc) -> new SnappyWriter(out)),
+    LZO(header_flags.LZO_1X1, in -> new LzoReader(in), (out, hc) -> new LzoWriter(out, hc));
 
     public static final Compression DEFAULT_APPEND = GZIP;
     public static final Compression DEFAULT_OPTIMIZED = GZIP;
@@ -35,8 +35,8 @@ public enum Compression {
         return this.reader.wrap(reader);
     }
 
-    public FileWriter wrap(FileWriter writer) throws IOException {
-        return this.writer.wrap(writer);
+    public FileWriter wrap(FileWriter writer, boolean highestCompression) throws IOException {
+        return this.writer.wrap(writer, highestCompression);
     }
 
     private static interface WrapReaderFunctor {
@@ -44,7 +44,7 @@ public enum Compression {
     }
 
     private static interface WrapWriterFunctor {
-        public FileWriter wrap(FileWriter out) throws IOException;
+        public FileWriter wrap(FileWriter out, boolean highestCompression) throws IOException;
     }
 
     public static Compression fromFlags(int flags) {

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/list/ReadWriteState.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/list/ReadWriteState.java
@@ -209,7 +209,7 @@ public final class ReadWriteState implements State {
         final List<EncodedTscHeaderForWrite> writeHeaders;
         try (FileChannelWriter fd = new FileChannelWriter(this.file.get(), recordOffset)) {
             {
-                final Writer writer = new Writer(fd, compression, useBuffer);
+                final Writer writer = new Writer(fd, compression, useBuffer, false);
 
                 /* Write the contents of each collection. */
                 writeHeaders = new ArrayList<>(tscList.size());
@@ -428,7 +428,7 @@ public final class ReadWriteState implements State {
             tscHdr.ts = ToXdr.timestamp(timestamp);
             tscHdr.records = ToXdr.filePos(encodedTsc);
 
-            FilePos pos = new Writer(fd, Compression.NONE, useBuffer).write(tscHdr);
+            FilePos pos = new Writer(fd, Compression.NONE, useBuffer, false).write(tscHdr);
             LOG.log(Level.FINEST, "tsdata header written at {0}", pos);
             return pos;
         }

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/ToXdrTables.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/ToXdrTables.java
@@ -404,7 +404,7 @@ public class ToXdrTables implements Closeable {
 
         public Writer newWriter() {
             assert Thread.holdsLock(this);
-            return new Writer(fd, compression, useBuffer);
+            return new Writer(fd, compression, useBuffer, true);
         }
 
         public long getBegin() {

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/TmpFile.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/TmpFile.java
@@ -27,7 +27,7 @@ public class TmpFile<T extends XdrAble> implements Closeable {
     private TmpFile(FileChannel fd, Compression compression) throws IOException {
         this.fd = fd;
         this.compression = compression;
-        this.fileIO = Any2.right(new XdrEncodingFileWriter(compression.wrap(new FileChannelWriter(fd, 0)), 64 * 1024));
+        this.fileIO = Any2.right(new XdrEncodingFileWriter(compression.wrap(new FileChannelWriter(fd, 0), false), 64 * 1024));
     }
 
     public TmpFile(Path dir, Compression compression) throws IOException {

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/LzoReader.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/reader/LzoReader.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import org.anarres.lzo.LzoAlgorithm;
 import org.anarres.lzo.LzoDecompressor;
-import org.anarres.lzo.LzoInputStream;
 import org.anarres.lzo.LzoLibrary;
+import org.anarres.lzo.LzopInputStream;
 
 public class LzoReader extends AbstractInputStreamReader {
     public static final LzoAlgorithm ALGORITHM = LzoAlgorithm.LZO1X;
@@ -18,9 +18,9 @@ public class LzoReader extends AbstractInputStreamReader {
         super(createLzoInputStream(newAdapter(in)));
     }
 
-    private static InputStream createLzoInputStream(InputStream adapter) {
+    private static InputStream createLzoInputStream(InputStream adapter) throws IOException {
         LzoDecompressor decompressor = LzoLibrary.getInstance().newDecompressor(ALGORITHM, null);
-        LzoInputStream lzo = new LzoInputStream(adapter, decompressor);
+        LzopInputStream lzo = new LzopInputStream(adapter);
         lzo.setInputBufferSize(64 * 1024);
         return lzo;
     }

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/LzoWriter.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/writer/LzoWriter.java
@@ -1,23 +1,25 @@
 package com.groupon.lex.metrics.history.xdr.support.writer;
 
-import com.groupon.lex.metrics.history.xdr.support.reader.LzoReader;
 import java.io.IOException;
 import java.io.OutputStream;
 import org.anarres.lzo.LzoAlgorithm;
 import org.anarres.lzo.LzoCompressor;
+import org.anarres.lzo.LzoConstraint;
 import org.anarres.lzo.LzoLibrary;
-import org.anarres.lzo.LzoOutputStream;
+import org.anarres.lzo.LzopConstants;
+import org.anarres.lzo.LzopOutputStream;
 
 public class LzoWriter extends AbstractOutputStreamWriter {
-    public static final LzoAlgorithm ALGORITHM = LzoReader.ALGORITHM;
+    public static final LzoAlgorithm ALGORITHM = LzoAlgorithm.LZO1X;
+    private static final long FLAGS = LzopConstants.F_CRC32_C | LzopConstants.F_CRC32_D | LzopConstants.F_ADLER32_C | LzopConstants.F_ADLER32_D;
 
-    public LzoWriter(FileWriter out) throws IOException {
-        super(createLzoOutputStream(newAdapter(out)));
+    public LzoWriter(FileWriter out, boolean highestCompression) throws IOException {
+        super(createLzoOutputStream(newAdapter(out), highestCompression));
     }
 
-    private static OutputStream createLzoOutputStream(OutputStream adapter) {
-        LzoCompressor compressor = LzoLibrary.getInstance().newCompressor(ALGORITHM, null);
-        LzoOutputStream lzo = new LzoOutputStream(adapter, compressor, 64 * 1024);
+    private static OutputStream createLzoOutputStream(OutputStream adapter, boolean highestCompression) throws IOException {
+        LzoCompressor compressor = LzoLibrary.getInstance().newCompressor(ALGORITHM, highestCompression ? LzoConstraint.COMPRESSION : null);
+        LzopOutputStream lzo = new LzopOutputStream(adapter, compressor, 64 * 1024, FLAGS);
         return lzo;
     }
 }

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/reader/FileChannelSegmentReaderTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/reader/FileChannelSegmentReaderTest.java
@@ -68,7 +68,7 @@ public class FileChannelSegmentReaderTest {
 
     private FilePos create(Compression compression) throws Exception {
         try (FileChannel fd = FileChannel.open(file, StandardOpenOption.WRITE)) {
-            return new AbstractSegmentWriter.Writer(fd, 32, compression)
+            return new AbstractSegmentWriter.Writer(fd, 32, compression, false)
                     .write(expected);
         }
     }

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/writer/AbstractSegmentWriterTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/writer/AbstractSegmentWriterTest.java
@@ -71,7 +71,7 @@ public class AbstractSegmentWriterTest {
     @Test
     public void write() throws Exception {
         GCCloseable<FileChannel> fd = new GCCloseable<>(FileChannel.open(file.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE));
-        FilePos pos = writeable.write(new AbstractSegmentWriter.Writer(fd.get(), 0, Compression.NONE), new long[]{9});
+        FilePos pos = writeable.write(new AbstractSegmentWriter.Writer(fd.get(), 0, Compression.NONE, false), new long[]{9});
 
         assertEquals(xdrAble, new FileChannelSegmentReader<>(XdrAbleImpl::new, fd, pos, Compression.NONE).decode());
     }
@@ -79,7 +79,7 @@ public class AbstractSegmentWriterTest {
     @Test
     public void writeCompressed() throws Exception {
         GCCloseable<FileChannel> fd = new GCCloseable<>(FileChannel.open(file.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE));
-        FilePos pos = writeable.write(new AbstractSegmentWriter.Writer(fd.get(), 0, Compression.DEFAULT_APPEND), new long[]{9});
+        FilePos pos = writeable.write(new AbstractSegmentWriter.Writer(fd.get(), 0, Compression.DEFAULT_APPEND, false), new long[]{9});
 
         assertEquals(xdrAble, new FileChannelSegmentReader<>(XdrAbleImpl::new, fd, pos, Compression.DEFAULT_APPEND).decode());
     }


### PR DESCRIPTION
Allow for compressions that have a high-compression method (ex: LZO-1X) to use high compression on table files.