### PR TITLE
Use gzip, as I saw some failing checksums with LZO 1X-999.

### DIFF
--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/Compression.java
@@ -18,8 +18,8 @@ public enum Compression {
     SNAPPY(header_flags.SNAPPY, in -> new SnappyReader(in), (out, hc) -> new SnappyWriter(out)),
     LZO(header_flags.LZO_1X1, in -> new LzoReader(in), (out, hc) -> new LzoWriter(out, hc));
 
-    public static final Compression DEFAULT_APPEND = LZO;
-    public static final Compression DEFAULT_OPTIMIZED = LZO;
+    public static final Compression DEFAULT_APPEND = GZIP;
+    public static final Compression DEFAULT_OPTIMIZED = GZIP;
 
     public final int compressionFlag;
     private final WrapReaderFunctor reader;


### PR DESCRIPTION
Not sure what's going on, but until I figure it out, use gzip, which is
known to work.