### PR TITLE
Fix race condition in ToXdrTables.

### DIFF
--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/ToXdrTables.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/ToXdrTables.java
@@ -355,7 +355,11 @@ public class ToXdrTables implements Closeable {
                             groupPathMap.put(grpRef, new ArrayList<>());
                         tagList = groupPathMap.get(grpRef);
                     }
-                    tagList.add(createTagTable(grpEntry.getKey(), grpEntry.getValue(), ctx));
+
+                    final tables_tag tables_tag = createTagTable(grpEntry.getKey(), grpEntry.getValue(), ctx);
+                    synchronized (tagList) {
+                        tagList.add(tables_tag);
+                    }
                 })
                 .join();
 
@@ -365,6 +369,7 @@ public class ToXdrTables implements Closeable {
                     tables_group tg = new tables_group();
                     tg.group_ref = pathIdx;
                     tg.tag_tbl = groupPathMap.get(pathIdx).toArray(new tables_tag[0]);
+                    assert tg.tag_tbl.length > 0;
                     return tg;
                 })
                 .toArray(tables_group[]::new));

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesValue.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesValue.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -44,7 +44,7 @@ import org.joda.time.DateTime;
  *
  * @author ariane
  */
-public interface TimeSeriesValue extends Cloneable, Tagged {
+public interface TimeSeriesValue extends Cloneable, Tagged, Comparable<TimeSeriesValue> {
     public DateTime getTimestamp();
     public GroupName getGroup();
 
@@ -59,4 +59,9 @@ public interface TimeSeriesValue extends Cloneable, Tagged {
     }
 
     public TimeSeriesValue clone();
+
+    @Override
+    public default int compareTo(TimeSeriesValue other) {
+        return getGroup().compareTo(other.getGroup());
+    }
 }


### PR DESCRIPTION
The race condition caused it to sometimes drop a group, due to lacking
synchronization on the intermediate arraylist during encoding.