### PR TITLE
Misc fixes

### DIFF
--- a/lib/src/main/java/com/groupon/lex/metrics/lib/sequence/SortedObjectSequence.java
+++ b/lib/src/main/java/com/groupon/lex/metrics/lib/sequence/SortedObjectSequence.java
@@ -146,8 +146,6 @@ public class SortedObjectSequence<T> implements ObjectSequence<T> {
             if (data.getRight().isPresent())
                 return data.getRight().get();
 
-            System.err.println("makePartition");
-
             final MappedObjectSequence<T> seq = data.getLeft().orElseThrow(IllegalStateException::new);
             int[] partitionMap = new ForwardSequence(0, seq.size()).toArray();
             swap(partitionMap, RANDOM.nextInt(partitionMap.length), 0);  // Choose a pivot and move it to the front.
@@ -170,7 +168,6 @@ public class SortedObjectSequence<T> implements ObjectSequence<T> {
                         makePartition(seq, Arrays.copyOfRange(partitionMap, 0, partitionIdx), comparator),
                         makePartition(seq, Arrays.copyOfRange(partitionMap, partitionIdx, partitionMap.length), comparator)));
             }
-            System.err.println(result);
             return result;
         }
 
@@ -389,7 +386,6 @@ public class SortedObjectSequence<T> implements ObjectSequence<T> {
                 combinedMapping[i] = mapping[index];
             }
 
-            System.err.println("remap on " + Arrays.toString(mapping) + "\n    with new mapping " + Arrays.toString(newMapping) + "\n    resulting in " + Arrays.toString(combinedMapping));
             return new MappedObjectSequence(underlying, combinedMapping);
         }
 

--- a/lib/src/test/java/com/groupon/lex/metrics/lib/BufferedIteratorTest.java
+++ b/lib/src/test/java/com/groupon/lex/metrics/lib/BufferedIteratorTest.java
@@ -16,19 +16,19 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 public class BufferedIteratorTest {
-    @Test(timeout = 2000)
+    @Test(timeout = 8000)
     public void empty_iterator_test() {
         Iterator<?> iterator = BufferedIterator.iterator(ForkJoinPool.commonPool(), Stream.empty().iterator());
 
         assertFalse(iterator.hasNext());
     }
 
-    @Test(expected = NoSuchElementException.class, timeout = 2000)
+    @Test(expected = NoSuchElementException.class, timeout = 8000)
     public void empty_iterator_next_test() {
         BufferedIterator.iterator(ForkJoinPool.commonPool(), Stream.empty().iterator()).next();
     }
 
-    @Test(timeout = 2000)
+    @Test(timeout = 8000)
     public void nonempty_iterator_test() {
         Iterator<?> iterator = BufferedIterator.iterator(ForkJoinPool.commonPool(), Stream.of("foobar").iterator());
 
@@ -37,7 +37,7 @@ public class BufferedIteratorTest {
         assertFalse(iterator.hasNext());
     }
 
-    @Test(timeout = 2000)
+    @Test(timeout = 8000)
     public void iteration() {
         List<Integer> visited = BufferedIterator.stream(ForkJoinPool.commonPool(), Stream.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20))
                 .collect(Collectors.toList());
@@ -45,7 +45,7 @@ public class BufferedIteratorTest {
         assertEquals(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20), visited);
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 80000)
     public void blocking_iteration() {
         Stream<Integer> stream = BufferedIterator.stream(ForkJoinPool.commonPool(), Stream.generate(new Supplier<Integer>() {
             private int i = 0;


### PR DESCRIPTION
- Increase timeouts for ``BufferedIterator`` tests, as they sometimes timed out on travis-ci.
- Remove stderr printing from ``SortedObjectSequence``.