### PR TITLE
Async collector

### DIFF
--- a/collectors/collectd/src/main/java/com/groupon/lex/metrics/collector/collectd/CollectdPushCollector.java
+++ b/collectors/collectd/src/main/java/com/groupon/lex/metrics/collector/collectd/CollectdPushCollector.java
@@ -33,8 +33,6 @@ package com.groupon.lex.metrics.collector.collectd;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.groupon.lex.metrics.GroupGenerator;
-import static com.groupon.lex.metrics.GroupGenerator.successResult;
 import com.groupon.lex.metrics.GroupName;
 import com.groupon.lex.metrics.Metric;
 import com.groupon.lex.metrics.MetricGroup;
@@ -43,6 +41,7 @@ import com.groupon.lex.metrics.MetricValue;
 import com.groupon.lex.metrics.SimpleGroupPath;
 import com.groupon.lex.metrics.SimpleMetric;
 import com.groupon.lex.metrics.SimpleMetricGroup;
+import com.groupon.lex.metrics.SynchronousGroupGenerator;
 import com.groupon.lex.metrics.Tags;
 import com.groupon.lex.metrics.collector.collectd.grammar.CollectdTags;
 import com.groupon.lex.metrics.httpd.EndpointRegistration;
@@ -52,6 +51,7 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import static java.util.Collections.EMPTY_MAP;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -61,6 +61,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -74,19 +75,20 @@ import javax.servlet.http.HttpServletResponse;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
-import lombok.NonNull;
 
 /**
  *
  * @author ariane
  */
-public class CollectdPushCollector implements GroupGenerator {
+public class CollectdPushCollector extends SynchronousGroupGenerator {
     public static final String API_ENDPOINT_BASE = "/collectd/jsonpush/";
     public static final Duration DROP_DURATION = Duration.standardHours(1);
-    private static final Type COLLECTD_TYPE = new TypeToken<List<CollectdMessage>>(){}.getType();
+    private static final Type COLLECTD_TYPE = new TypeToken<List<CollectdMessage>>() {
+    }.getType();
     private static final Metric UP_METRIC = new SimpleMetric(MetricName.valueOf("up"), Boolean.TRUE);
     private static final Metric DOWN_METRIC = new SimpleMetric(MetricName.valueOf("up"), Boolean.FALSE);
 
@@ -117,7 +119,8 @@ public class CollectdPushCollector implements GroupGenerator {
                 return s;
 
             final String tag_string = s.substring(tags_brace_open + 1, s.length() - 1);
-            if (!tag_string.isEmpty()) out_tagmap.putAll(CollectdTags.parse(tag_string));
+            if (!tag_string.isEmpty())
+                out_tagmap.putAll(CollectdTags.parse(tag_string));
 
             return s.substring(0, tags_brace_open);
         }
@@ -139,10 +142,14 @@ public class CollectdPushCollector implements GroupGenerator {
             return new CollectdKey(host, plugin, plugin_instance, type, type_instance);
         }
 
-        public int metricCount() { return values.size(); }
+        public int metricCount() {
+            return values.size();
+        }
 
         /**
-         * Work around for Google gson parser emitting numbers as 'lazily parsed' numbers.
+         * Work around for Google gson parser emitting numbers as 'lazily
+         * parsed' numbers.
+         *
          * @param elem An instance of a gson lazily parsed number.
          * @return A metric value containing the number.
          */
@@ -157,7 +164,7 @@ public class CollectdPushCollector implements GroupGenerator {
             }
             try {
                 return MetricValue.fromDblValue(Double.parseDouble(num));
-            } catch (NumberFormatException ex ) {
+            } catch (NumberFormatException ex) {
                 /* SKIP */
             }
             return MetricValue.fromStrValue(num);
@@ -176,20 +183,22 @@ public class CollectdPushCollector implements GroupGenerator {
 
         public MetricGroup toMetricGroup(SimpleGroupPath base_path) {
             final CollectdKey key = getKey();  // Use key, as it parses the tags for us.
-            final Map<String, MetricValue> tag_map = new HashMap<String, MetricValue>() {{
-                put("host", MetricValue.fromStrValue(host));
-                putAll(key.tags.entrySet().stream()
-                        .collect(Collectors.toMap(
-                                Map.Entry::getKey,
-                                (entry -> entry.getValue().mapCombine(MetricValue::fromStrValue, MetricValue::fromNumberValue)))));
-            }};
+            final Map<String, MetricValue> tag_map = new HashMap<String, MetricValue>() {
+                {
+                    put("host", MetricValue.fromStrValue(host));
+                    putAll(key.tags.entrySet().stream()
+                            .collect(Collectors.toMap(
+                                    Map.Entry::getKey,
+                                    (entry -> entry.getValue().mapCombine(MetricValue::fromStrValue, MetricValue::fromNumberValue)))));
+                }
+            };
 
             final GroupName group = GroupName.valueOf(
                     SimpleGroupPath.valueOf(Stream.concat(
                             base_path.getPath().stream(),
                             Stream.of(key.plugin, key.plugin_instance)
-                                    .filter(x -> x != null)
-                                    .filter(s -> !s.isEmpty()))
+                            .filter(x -> x != null)
+                            .filter(s -> !s.isEmpty()))
                             .collect(Collectors.toList())),
                     Tags.valueOf(tag_map));
 
@@ -222,14 +231,15 @@ public class CollectdPushCollector implements GroupGenerator {
     }
 
     public CollectdPushCollector(@NonNull EndpointRegistration er, @NonNull SimpleGroupPath base_path, @NonNull String name) {
-        if (name.isEmpty()) throw new IllegalArgumentException("empty endpoint name");
+        if (name.isEmpty())
+            throw new IllegalArgumentException("empty endpoint name");
 
         er.addEndpoint(API_ENDPOINT_BASE + name, new Endpoint());
         basePath = base_path;
     }
 
     @Override
-    public GroupCollection getGroups() {
+    public Collection<? extends MetricGroup> getGroups(CompletableFuture<TimeoutObject> timeout) {
         final DateTime now = new DateTime(DateTimeZone.UTC);
         final DateTime drop = now.minus(DROP_DURATION);
 
@@ -251,7 +261,7 @@ public class CollectdPushCollector implements GroupGenerator {
                     .collect(Collectors.toSet());
             // Collect the set of hosts that are 'down'.
             final Map<String, DateTime> down_hosts = knownHosts.entrySet().stream()
-                    .filter(entry -> entry.getValue().isAfter(drop))  // Don't remember host names for ever.
+                    .filter(entry -> entry.getValue().isAfter(drop)) // Don't remember host names for ever.
                     .filter(entry -> !up_hosts.contains(entry.getKey())) // No need to remember hosts that emitted metrics.
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             // Create metrics for all up/down hosts.
@@ -264,17 +274,18 @@ public class CollectdPushCollector implements GroupGenerator {
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
             // Done, return result.
-            return successResult(
-                    Stream.of(msg_stream, up_hosts_stream, down_hosts_stream)
-                            .flatMap(Function.identity())
-                            .collect(Collectors.toList()));
+            return Stream.of(msg_stream, up_hosts_stream, down_hosts_stream)
+                    .flatMap(Function.identity())
+                    .collect(Collectors.toList());
         } finally {
             messages.clear();
             lck.unlock();
         }
     }
 
-    /** Return a metric group indicating if the host is up or down. */
+    /**
+     * Return a metric group indicating if the host is up or down.
+     */
     private MetricGroup up_down_host_(String host, boolean up) {
         final GroupName group = GroupName.valueOf(
                 getBasePath(),

--- a/collectors/http/src/test/java/com/groupon/lex/metrics/collector/httpget/UrlGetCollectorTest.java
+++ b/collectors/http/src/test/java/com/groupon/lex/metrics/collector/httpget/UrlGetCollectorTest.java
@@ -48,7 +48,6 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockserver.client.server.MockServerClient;
@@ -58,6 +57,12 @@ import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.verify.VerificationTimes;
 import com.groupon.lex.metrics.resolver.NameBoundResolver;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.After;
+import org.junit.Before;
 
 /**
  *
@@ -69,12 +74,24 @@ public class UrlGetCollectorTest {
 
     private MockServerClient mockServerClient;
 
+    private ExecutorService threadpool;
+
     private UrlGetCollector endpoint(String path) {
         return new UrlGetCollector(SimpleGroupPath.valueOf("test"), new UrlPattern(StringTemplate.fromString("http://localhost:" + mockServerRule.getPort() + path), NameBoundResolver.EMPTY));
     }
 
+    @Before
+    public void setup() {
+        threadpool = Executors.newSingleThreadExecutor();
+    }
+
+    @After
+    public void cleanup() {
+        threadpool.shutdownNow();
+    }
+
     @Test(timeout = 10000)
-    public void scrape() {
+    public void scrape() throws Exception {
         final HttpRequest REQUEST = HttpRequest.request("/scrape")
                 .withMethod("GET");
         final UrlGetCollector collector = endpoint("/scrape");
@@ -84,20 +101,19 @@ public class UrlGetCollectorTest {
                         .withHeader("Test-Header", "Test-Response")
                         .withHeader("Double-Value", "17.1"));
 
-        GroupGenerator.GroupCollection groups = collector.getGroups();
+        Collection<MetricGroup> groups = GroupGenerator.deref(collector.getGroups(threadpool, new CompletableFuture<>()));
         mockServerClient.verify(REQUEST, VerificationTimes.once());
-        assertTrue(groups.isSuccessful());
 
-        assertThat(groups.getGroups().stream().map(MetricGroup::getName).collect(Collectors.toList()),
+        assertThat(groups.stream().map(MetricGroup::getName).collect(Collectors.toList()),
                 Matchers.contains(GroupName.valueOf("test")));
 
         // Verify data in test_group.
-        final Map<MetricName, MetricValue> metrics = Arrays.stream(groups.getGroups().stream()
-                        .filter(mg -> mg.getName().equals(GroupName.valueOf("test")))
-                        .findFirst()
-                        .get()
-                        .getMetrics()
-                )
+        final Map<MetricName, MetricValue> metrics = Arrays.stream(groups.stream()
+                .filter(mg -> mg.getName().equals(GroupName.valueOf("test")))
+                .findFirst()
+                .get()
+                .getMetrics()
+        )
                 .collect(Collectors.toMap(Metric::getName, Metric::getValue));
         System.err.println(metrics);
         assertThat(metrics, allOf(
@@ -111,7 +127,7 @@ public class UrlGetCollectorTest {
     }
 
     @Test(timeout = 10000)
-    public void scrape_without_contentlength() {
+    public void scrape_without_contentlength() throws Exception {
         final HttpRequest REQUEST = HttpRequest.request("/scrapeWCL")
                 .withMethod("GET");
         final UrlGetCollector collector = endpoint("/scrapeWCL");
@@ -120,20 +136,19 @@ public class UrlGetCollectorTest {
                 .respond(HttpResponse.response("chocoladevla")
                         .withConnectionOptions(ConnectionOptions.connectionOptions().withSuppressContentLengthHeader(true).withCloseSocket(true)));
 
-        GroupGenerator.GroupCollection groups = collector.getGroups();
+        Collection<MetricGroup> groups = GroupGenerator.deref(collector.getGroups(threadpool, new CompletableFuture<>()));
         mockServerClient.verify(REQUEST, VerificationTimes.once());
-        assertTrue(groups.isSuccessful());
 
-        assertThat(groups.getGroups().stream().map(MetricGroup::getName).collect(Collectors.toList()),
+        assertThat(groups.stream().map(MetricGroup::getName).collect(Collectors.toList()),
                 Matchers.contains(GroupName.valueOf("test")));
 
         // Verify data in test_group.
-        final Map<MetricName, MetricValue> metrics = Arrays.stream(groups.getGroups().stream()
-                        .filter(mg -> mg.getName().equals(GroupName.valueOf("test")))
-                        .findFirst()
-                        .get()
-                        .getMetrics()
-                )
+        final Map<MetricName, MetricValue> metrics = Arrays.stream(groups.stream()
+                .filter(mg -> mg.getName().equals(GroupName.valueOf("test")))
+                .findFirst()
+                .get()
+                .getMetrics()
+        )
                 .collect(Collectors.toMap(Metric::getName, Metric::getValue));
         System.err.println(metrics);
         assertThat(metrics, allOf(

--- a/collectors/jmx/src/main/java/com/groupon/lex/metrics/jmx/JmxBuilder.java
+++ b/collectors/jmx/src/main/java/com/groupon/lex/metrics/jmx/JmxBuilder.java
@@ -83,7 +83,7 @@ public class JmxBuilder implements CollectorBuilder, MainStringList, AcceptTagSe
                 port = arg.getString("port");  // Backwards compatibility: port used to be a string.
             }
 
-            MetricListener listener = new MetricListener(new JmxClient("service:jmx:rmi:///jndi/rmi://" + host + ":" + port + "/jmxrmi"), includes, arg);
+            MetricListener listener = new MetricListener(new JmxClient("service:jmx:rmi:///jndi/rmi://" + host + ":" + port + "/jmxrmi", true), includes, arg);
             listener.enable();
             return listener;
         }

--- a/collectors/jmx/src/main/java/com/groupon/lex/metrics/jmx/JmxClient.java
+++ b/collectors/jmx/src/main/java/com/groupon/lex/metrics/jmx/JmxClient.java
@@ -31,21 +31,27 @@
  */
 package com.groupon.lex.metrics.jmx;
 
+import com.groupon.lex.metrics.lib.GCCloseable;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.management.ListenerNotFoundException;
 import javax.management.MBeanServerConnection;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
+import javax.security.auth.Subject;
 import lombok.Getter;
+import lombok.NonNull;
 
 /**
  *
@@ -59,8 +65,7 @@ public class JmxClient implements AutoCloseable {
     private static final Logger LOG = Logger.getLogger(JmxClient.class.getName());
     @Getter
     private final Optional<JMXServiceURL> jmxUrl;
-    private Optional<JMXConnector> jmx_factory_;
-    private MBeanServerConnection conn_;  // conn_ == null -> connection needs recovery
+    private CompletableFuture<GCCloseable<JMXConnector>> conn_;  // conn_ == null -> connection needs recovery
     private final Collection<ConnectionDecorator> recovery_callbacks_ = new ArrayList<>();
 
     /**
@@ -70,8 +75,7 @@ public class JmxClient implements AutoCloseable {
      */
     public JmxClient() {
         jmxUrl = Optional.empty();
-        jmx_factory_ = Optional.empty();
-        conn_ = ManagementFactory.getPlatformMBeanServer();
+        conn_ = CompletableFuture.completedFuture(new GCCloseable<>(new LocalhostJMXConnectorStub()));
     }
 
     /**
@@ -80,7 +84,7 @@ public class JmxClient implements AutoCloseable {
      * @param connection_url the JMX server URL
      * @throws IOException if the connection cannot be established
      */
-    public JmxClient(JMXServiceURL connection_url) throws IOException {
+    public JmxClient(@NonNull JMXServiceURL connection_url) throws IOException {
         this(connection_url, false);
     }
 
@@ -91,32 +95,9 @@ public class JmxClient implements AutoCloseable {
      * @param lazy if set, connection creation will be deferred
      * @throws IOException if the connection cannot be established
      */
-    public JmxClient(JMXServiceURL connection_url, boolean lazy) throws IOException {
+    public JmxClient(@NonNull JMXServiceURL connection_url, boolean lazy) throws IOException {
         jmxUrl = Optional.of(connection_url);
-        jmx_factory_ = Optional.of(JMXConnectorFactory.newJMXConnector(jmxUrl.get(), null));
-        if (lazy) {
-            conn_ = null;
-        } else {
-            try {
-                jmx_factory_.get().connect();
-            } catch (IOException ex) {
-                LOG.log(Level.WARNING, "unable to connect");
-                conn_ = null;
-                return;
-            }
-            try {
-                conn_ = jmx_factory_.get().getMBeanServerConnection();
-            } catch (IOException ex) {
-                LOG.log(Level.WARNING, "unable to connect");
-                try {
-                    jmx_factory_.get().close();
-                } catch (IOException ex1) {
-                    LOG.log(Level.WARNING, "unable to close failed connection attempt", ex1);
-                    /* Eat exception. */
-                }
-                conn_ = null;
-            }
-        }
+        conn_ = null;
     }
 
     /**
@@ -127,7 +108,7 @@ public class JmxClient implements AutoCloseable {
      * @throws MalformedURLException if the JMX URL is invalid
      * @throws IOException if the connection cannot be established
      */
-    public JmxClient(String connection_url) throws MalformedURLException, IOException {
+    public JmxClient(@NonNull String connection_url) throws MalformedURLException, IOException {
         this(new JMXServiceURL(connection_url));
     }
 
@@ -140,7 +121,7 @@ public class JmxClient implements AutoCloseable {
      * @throws MalformedURLException if the JMX URL is invalid
      * @throws IOException if the connection cannot be established
      */
-    public JmxClient(String connection_url, boolean lazy) throws MalformedURLException, IOException {
+    public JmxClient(@NonNull String connection_url, boolean lazy) throws MalformedURLException, IOException {
         this(new JMXServiceURL(connection_url), lazy);
     }
 
@@ -155,40 +136,46 @@ public class JmxClient implements AutoCloseable {
      * connection creation, cancel the future with the interruption flag set to
      * true.
      */
-    public CompletableFuture<MBeanServerConnection> getConnection(Executor threadpool) {
-        return CompletableFuture.supplyAsync(
-                () -> {
-                    synchronized (this) {
-                        Optional<MBeanServerConnection> optionalConnection = getOptionalConnection();
-                        if (optionalConnection.isPresent())
-                            return optionalConnection.get();
+    public synchronized CompletableFuture<GCCloseable<JMXConnector>> getConnection(Executor threadpool) {
+        if (conn_ != null && conn_.isCompletedExceptionally()) conn_ = null;
+        if (conn_ != null && conn_.isDone() && !conn_.isCompletedExceptionally()) {
+            try {
+                conn_.get().get().getMBeanServerConnection().getMBeanCount();
+            } catch (Exception ex) {
+                conn_ = null;  // Connection gone bad.
+            }
+        }
 
-                        try {
-                            /* Re-create factory, because apparently they cannot re-create a broken connection. */
-                            if (jmxUrl.isPresent())
-                                jmx_factory_ = Optional.of(JMXConnectorFactory.newJMXConnector(jmxUrl.get(), null));  // May throw
-
-                            /* Attempt to recreate the connection and replay the listeners. */
-                            JMXConnector factory = jmx_factory_.orElseThrow(() -> new IOException("cannot recover from broken connection to local MBean Server"));
-                            factory.connect();  // May throw
+        if (conn_ == null) {
+            try {
+                conn_ = CompletableFuture.completedFuture(new GCCloseable<>(JMXConnectorFactory.newJMXConnector(jmxUrl.get(), null)))
+                        .thenApplyAsync(
+                                (factory) -> {
+                                    try {
+                                        factory.get().connect();
+                                        return factory;
+                                    } catch (IOException ex) {
+                                        throw new RuntimeException("unable to connect to " + jmxUrl.get(), ex);
+                                    }
+                                }, threadpool)
+                        .thenApply((factory) -> {
                             try {
-                                conn_ = factory.getMBeanServerConnection();
+                                MBeanServerConnection conn = factory.get().getMBeanServerConnection();
                                 for (ConnectionDecorator cb
                                              : recovery_callbacks_)
-                                    cb.apply(conn_);
+                                    cb.apply(conn);
+                                return factory;
                             } catch (IOException ex) {
-                                /* Cleanup on initialization failure. */
-                                conn_ = null;
-                                factory.close();
-                                throw ex;
+                                throw new RuntimeException("running recovery callbacks failed", ex);
                             }
-                            return conn_;
-                        } catch (IOException ex) {
-                            throw new RuntimeException(ex.getMessage(), ex);
-                        }
-                    }
-                },
-                threadpool);
+                        });
+            } catch (IOException | RuntimeException ex) {
+                CompletableFuture<GCCloseable<JMXConnector>> fail = new CompletableFuture<>();
+                fail.completeExceptionally(ex);
+                return fail;
+            }
+        }
+        return conn_;
     }
 
     /**
@@ -198,24 +185,18 @@ public class JmxClient implements AutoCloseable {
      * @return An optional with a connection, or empty optional indicating there
      * is no connection.
      */
-    public Optional<MBeanServerConnection> getOptionalConnection() {
-        if (conn_ != null) {
-            /* Verify the connection is valid. */
+    public synchronized Optional<MBeanServerConnection> getOptionalConnection() {
+        if (conn_ != null && conn_.isCompletedExceptionally()) conn_ = null;
+        if (conn_ != null && conn_.isDone() && !conn_.isCompletedExceptionally()) {
             try {
-                conn_.getMBeanCount();
-            } catch (IOException ex) {
-                try {
-                    /* Connection is bad/lost. */
-                    jmx_factory_
-                            .orElseThrow(() -> new IOException("cannot recover from broken connection to local MBean Server"))
-                            .close();
-                } catch (IOException ex1) {
-                    Logger.getLogger(JmxClient.class.getName()).log(Level.SEVERE, "failed to close failing connection", ex1);
-                }
-                conn_ = null;
+                MBeanServerConnection result = conn_.get().get().getMBeanServerConnection();
+                result.getMBeanCount();
+                return Optional.of(result);
+            } catch (Exception ex) {
+                conn_ = null;  // Connection gone bad.
             }
         }
-        return Optional.ofNullable(conn_);
+        return Optional.empty();
     }
 
     /**
@@ -233,18 +214,7 @@ public class JmxClient implements AutoCloseable {
         try {
             if (conn != null) cb.apply(conn);
         } catch (IOException ex) {
-            Logger.getLogger(getClass().getName()).log(Level.FINE, "connection error while adding callback", ex);
-            /* Silently ignore: connection is bad and next time a connection is requested, the callback will be invoked. */
-
-            if (jmx_factory_.isPresent()) {
-                // Cleanup on initialization failure.
-                conn_ = null;
-                try {
-                    jmx_factory_.get().close();
-                } catch (IOException ex1) {
-                    Logger.getLogger(JmxClient.class.getName()).log(Level.WARNING, "failed to close failing connection", ex1);
-                }
-            }
+            conn_ = null;
         }
     }
 
@@ -262,7 +232,50 @@ public class JmxClient implements AutoCloseable {
 
     @Override
     public synchronized void close() throws IOException {
-        if (jmx_factory_.isPresent()) jmx_factory_.get().close();
         conn_ = null;
+    }
+
+    private static class LocalhostJMXConnectorStub implements JMXConnector {
+        @Override
+        public void connect() throws IOException {
+        }
+
+        @Override
+        public void connect(Map<String, ?> env) throws IOException {
+        }
+
+        @Override
+        public MBeanServerConnection getMBeanServerConnection() throws IOException {
+            return ManagementFactory.getPlatformMBeanServer();
+        }
+
+        @Override
+        public MBeanServerConnection getMBeanServerConnection(Subject delegationSubject) throws IOException {
+            return getMBeanServerConnection();
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+
+        @Override
+        public void addConnectionNotificationListener(NotificationListener listener, NotificationFilter filter, Object handback) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void removeConnectionNotificationListener(NotificationListener listener) throws ListenerNotFoundException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void removeConnectionNotificationListener(NotificationListener l, NotificationFilter f, Object handback) throws ListenerNotFoundException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getConnectionId() throws IOException {
+            return "localhost";
+        }
     }
 }

--- a/collectors/jmx/src/main/java/com/groupon/lex/metrics/jmx/JmxClient.java
+++ b/collectors/jmx/src/main/java/com/groupon/lex/metrics/jmx/JmxClient.java
@@ -155,16 +155,14 @@ public class JmxClient implements AutoCloseable {
      * connection creation, cancel the future with the interruption flag set to
      * true.
      */
-    public synchronized CompletableFuture<MBeanServerConnection> getConnection(Executor threadpool) {
-        {
-            Optional<MBeanServerConnection> optionalConnection = getOptionalConnection();
-            if (optionalConnection.isPresent())
-                return CompletableFuture.completedFuture(optionalConnection.get());
-        }
-
+    public CompletableFuture<MBeanServerConnection> getConnection(Executor threadpool) {
         return CompletableFuture.supplyAsync(
                 () -> {
                     synchronized (this) {
+                        Optional<MBeanServerConnection> optionalConnection = getOptionalConnection();
+                        if (optionalConnection.isPresent())
+                            return optionalConnection.get();
+
                         try {
                             /* Re-create factory, because apparently they cannot re-create a broken connection. */
                             if (jmxUrl.isPresent())

--- a/collectors/jmx/src/main/java/com/groupon/lex/metrics/jmx/JmxClient.java
+++ b/collectors/jmx/src/main/java/com/groupon/lex/metrics/jmx/JmxClient.java
@@ -81,25 +81,41 @@ public class JmxClient implements AutoCloseable {
      * @throws IOException if the connection cannot be established
      */
     public JmxClient(JMXServiceURL connection_url) throws IOException {
+        this(connection_url, false);
+    }
+
+    /**
+     * Create a new client, connecting to the specified URL.
+     *
+     * @param connection_url the JMX server URL
+     * @param lazy if set, connection creation will be deferred
+     * @throws IOException if the connection cannot be established
+     */
+    public JmxClient(JMXServiceURL connection_url, boolean lazy) throws IOException {
         jmxUrl = Optional.of(connection_url);
         jmx_factory_ = Optional.of(JMXConnectorFactory.newJMXConnector(jmxUrl.get(), null));
-        try {
-            jmx_factory_.get().connect();
-        } catch (IOException ex) {
-            LOG.log(Level.WARNING, "unable to connect");
+        if (lazy) {
             conn_ = null;
-        }
-        try {
-            conn_ = jmx_factory_.get().getMBeanServerConnection();
-        } catch (IOException ex) {
-            LOG.log(Level.WARNING, "unable to connect");
+        } else {
             try {
-                jmx_factory_.get().close();
-            } catch (IOException ex1) {
-                LOG.log(Level.WARNING, "unable to close failed connection attempt", ex1);
-                /* Eat exception. */
+                jmx_factory_.get().connect();
+            } catch (IOException ex) {
+                LOG.log(Level.WARNING, "unable to connect");
+                conn_ = null;
+                return;
             }
-            conn_ = null;
+            try {
+                conn_ = jmx_factory_.get().getMBeanServerConnection();
+            } catch (IOException ex) {
+                LOG.log(Level.WARNING, "unable to connect");
+                try {
+                    jmx_factory_.get().close();
+                } catch (IOException ex1) {
+                    LOG.log(Level.WARNING, "unable to close failed connection attempt", ex1);
+                    /* Eat exception. */
+                }
+                conn_ = null;
+            }
         }
     }
 
@@ -113,6 +129,19 @@ public class JmxClient implements AutoCloseable {
      */
     public JmxClient(String connection_url) throws MalformedURLException, IOException {
         this(new JMXServiceURL(connection_url));
+    }
+
+    /**
+     * Create a new client, connecting to the specified URL.
+     *
+     * @param connection_url the JMX server URL, example:
+     * "service:jmx:rmi:///jndi/rmi://:9999/jmxrmi"
+     * @param lazy if set, connection creation will be deferred
+     * @throws MalformedURLException if the JMX URL is invalid
+     * @throws IOException if the connection cannot be established
+     */
+    public JmxClient(String connection_url, boolean lazy) throws MalformedURLException, IOException {
+        this(new JMXServiceURL(connection_url), lazy);
     }
 
     /**

--- a/collectors/jmx/src/test/java/com/groupon/lex/metrics/jmx/MBeanGroupTest.java
+++ b/collectors/jmx/src/test/java/com/groupon/lex/metrics/jmx/MBeanGroupTest.java
@@ -127,7 +127,7 @@ public class MBeanGroupTest {
         test_value.setStringval("foobar");
         test_value.getNested().setDblval(17);
 
-        Metric[] metrics = mbg.getMetrics(jmx.getConnection(threadpool).get()).get().getMetrics();
+        Metric[] metrics = mbg.getMetrics(jmx.getConnection(threadpool).get().get().getMBeanServerConnection()).get().getMetrics();
 
         /**
          * Create metrics map for easy test asserting.

--- a/impl/src/main/java/com/groupon/lex/metrics/MetricRegistryInstance.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/MetricRegistryInstance.java
@@ -33,23 +33,32 @@ package com.groupon.lex.metrics;
 
 import com.groupon.lex.metrics.api.endpoints.ListMetrics;
 import com.groupon.lex.metrics.httpd.EndpointRegistration;
+import com.groupon.lex.metrics.lib.Any2;
 import com.groupon.lex.metrics.misc.MonitorMonitor;
 import com.groupon.lex.metrics.timeseries.Alert;
 import com.groupon.lex.metrics.timeseries.ExpressionLookBack;
 import com.groupon.lex.metrics.timeseries.MutableTimeSeriesValue;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
 import com.groupon.lex.metrics.timeseries.TimeSeriesTransformer;
-import com.groupon.lex.metrics.timeseries.TimeSeriesValue;
 import com.groupon.lex.metrics.timeseries.expression.Context;
 import com.groupon.lex.metrics.timeseries.expression.MutableContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import static java.util.Collections.singleton;
 import java.util.List;
 import java.util.Objects;
 import static java.util.Objects.requireNonNull;
 import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -66,7 +75,19 @@ import org.joda.time.Duration;
  * @author ariane
  */
 public abstract class MetricRegistryInstance implements MetricRegistry, AutoCloseable {
-    private static final Logger logger = Logger.getLogger(MetricRegistryInstance.class.getName());
+    private static final Logger LOG = Logger.getLogger(MetricRegistryInstance.class.getName());
+    private static final AtomicLong THREADPOOL_ID = new AtomicLong();
+    private static final ExecutorService THREADPOOL = new ThreadPoolExecutor(4, 1000,
+            5L, TimeUnit.MINUTES,
+            new SynchronousQueue<>(),
+            (Runnable r) -> {
+                Thread thr = new Thread(r);
+                thr.setDaemon(true);
+                thr.setName("metric-registry-thread-0x" + Long.toUnsignedString(THREADPOOL_ID.incrementAndGet() - 1L, 16));
+                return thr;
+            });
+    private static final long MAX_COLLECTOR_WAIT_MSEC = 29 * 1000;  // msec
+    private static final long COLLECTOR_POST_TIMEOUT_MSEC = 1 * 1000;  // msec
     private final Collection<GroupGenerator> generators_ = new ArrayList<>();
     private long failed_collections_ = 0;
     private final boolean has_config_;
@@ -84,7 +105,7 @@ public abstract class MetricRegistryInstance implements MetricRegistry, AutoClos
         decorators_.add(new MonitorMonitor(this));
         now_ = requireNonNull(now);
         list_metrics_ = new ListMetrics();
-        getApi().addEndpoint("/monsoon/metrics", list_metrics_);
+        api_.addEndpoint("/monsoon/metrics", list_metrics_);
     }
 
     protected MetricRegistryInstance(boolean has_config, EndpointRegistration api) {
@@ -92,7 +113,9 @@ public abstract class MetricRegistryInstance implements MetricRegistry, AutoClos
     }
 
     @Override
-    public EndpointRegistration getApi() { return api_; }
+    public EndpointRegistration getApi() {
+        return api_;
+    }
 
     public synchronized GroupGenerator add(GroupGenerator g) {
         generators_.add(g);
@@ -104,63 +127,172 @@ public abstract class MetricRegistryInstance implements MetricRegistry, AutoClos
     }
 
     /**
-     * Retrieve the number of collectors that encountered a failure during the last call to streamGroups().
+     * Retrieve the number of collectors that encountered a failure during the
+     * last call to streamGroups().
+     *
      * @return The number of collectors that failed.
      */
-    public long getFailedCollections() { return failed_collections_; }
-    /**
-     * Retrieve timing for scrape.
-     * @return The duration it took to complete all scrapes.
-     */
-    public Optional<Duration> getScrapeDuration() { return scrape_duration_; }
-    /**
-     * Retrieve timing for rule evaluation.
-     * @return The duration it took to evaluate all rules.
-     */
-    public Optional<Duration> getRuleEvalDuration() { return rule_eval_duration_; }
-    /**
-     * Retrieve timing for processor to handle the data.
-     * @return The duration it took for the processor, to push all the data out.
-     */
-    public Optional<Duration> getProcessorDuration() { return processor_duration_; }
-    /**
-     * Update the processor duration.
-     * @param duration The time spent in the processor.
-     */
-    public void updateProcessorDuration(Duration duration) { processor_duration_ = Optional.of(duration); }
-
-    private Stream<TimeSeriesValue> streamGroups() {
-        return streamGroups(now());
+    public long getFailedCollections() {
+        return failed_collections_;
     }
 
-    private synchronized Stream<TimeSeriesValue> streamGroups(DateTime now) {
+    /**
+     * Retrieve timing for scrape.
+     *
+     * @return The duration it took to complete all scrapes.
+     */
+    public Optional<Duration> getScrapeDuration() {
+        return scrape_duration_;
+    }
+
+    /**
+     * Retrieve timing for rule evaluation.
+     *
+     * @return The duration it took to evaluate all rules.
+     */
+    public Optional<Duration> getRuleEvalDuration() {
+        return rule_eval_duration_;
+    }
+
+    /**
+     * Retrieve timing for processor to handle the data.
+     *
+     * @return The duration it took for the processor, to push all the data out.
+     */
+    public Optional<Duration> getProcessorDuration() {
+        return processor_duration_;
+    }
+
+    /**
+     * Update the processor duration.
+     *
+     * @param duration The time spent in the processor.
+     */
+    public void updateProcessorDuration(Duration duration) {
+        processor_duration_ = Optional.of(duration);
+    }
+
+    private synchronized Stream<MutableTimeSeriesValue> streamGroups(DateTime now) {
         final long t0 = System.nanoTime();
 
-        List<GroupGenerator.GroupCollection> collections = generators_.parallelStream()
-                .map(GroupGenerator::getGroups)
-                .collect(Collectors.toList());
+        final CompletableFuture<GroupGenerator.TimeoutObject> timeout = new CompletableFuture<>();
+        Collection<MetricGroup> collections = derefFutures(generators_.stream()
+                .map(generator -> {
+                    try {
+                        return generator.getGroups(THREADPOOL, timeout);
+                    } catch (Exception ex) {
+                        CompletableFuture<? extends Collection<? extends MetricGroup>> failure = new CompletableFuture<>();
+                        failure.completeExceptionally(ex);
+                        return singleton(failure);
+                    }
+                })
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList()),
+                t0,
+                timeout);
 
-        /* Count collection failures. */
-        failed_collections_ = collections.stream()
-                .filter((result) -> !result.isSuccessful())
-                .count();
         /* Measure end time of collections. */
         final long t_collections = System.nanoTime();
         scrape_duration_ = Optional.of(Duration.millis(TimeUnit.NANOSECONDS.toMillis(t_collections - t0)));
 
-        Stream<TimeSeriesValue> groups = collections.stream()
-                .map(GroupGenerator.GroupCollection::getGroups)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toMap(MetricGroup::getName, Function.identity(), (x, y) -> y))  // Resolve group-name conflict, such that latest metric wins.
+        Stream<MutableTimeSeriesValue> groups = collections.stream()
+                .collect(Collectors.toMap(MetricGroup::getName, Function.identity(), (x, y) -> y)) // Resolve group-name conflict, such that latest metric wins.
                 .values()
                 .stream()
                 .map((mg) -> new MutableTimeSeriesValue(now, mg.getName(), Arrays.stream(mg.getMetrics()), Metric::getName, Metric::getValue));
         return groups;
     }
 
-    @Override
-    public synchronized GroupName[] getGroupNames() {
-        return streamGroups().map(TimeSeriesValue::getGroup).toArray(GroupName[]::new);
+    /**
+     * Handles collecting the future arguments, correctly firing the timeout.
+     * This function also updates the failed_collections_ member variable.
+     *
+     * @param futures The futures of MetricGroups to dereference.
+     * @param t0_nsec The starting time of the scrape.
+     * @param timeout The future that informs collectors of the timeout event.
+     * @return The dereferenced data from all futures that completed
+     * successfully and on time.
+     */
+    private Collection<MetricGroup> derefFutures(Collection<CompletableFuture<? extends Collection<? extends MetricGroup>>> futures,
+                                                 long t0_nsec,
+                                                 CompletableFuture<GroupGenerator.TimeoutObject> timeout) {
+        long tDeadline1 = t0_nsec + TimeUnit.MILLISECONDS.toNanos(MAX_COLLECTOR_WAIT_MSEC);
+        long tDeadline2 = t0_nsec + TimeUnit.MILLISECONDS.toNanos(COLLECTOR_POST_TIMEOUT_MSEC);
+
+        final List<MetricGroup> result = new ArrayList<>();
+        final BlockingQueue<Any2<Collection<? extends MetricGroup>, Throwable>> readyQueue = new LinkedBlockingQueue<>();
+        int failCount = 0;
+        int pendingCount = futures.size();
+        futures.forEach(fut -> {
+            fut.handle((value, exc) -> {
+                if (exc != null) {
+                    if (!(exc instanceof CancellationException))
+                        LOG.log(Level.INFO, "collector failed", exc);
+                    readyQueue.add(Any2.right(exc));
+                }
+                if (value != null)
+                    readyQueue.add(Any2.left(value));
+                return null;
+            });
+        });
+
+        // Collect everything that completes on time.
+        while (pendingCount > 0) {
+            final long tNow = System.nanoTime();
+            if (tDeadline1 - tNow <= 0) break;  // GUARD
+
+            final Any2<Collection<? extends MetricGroup>, Throwable> readyItem;
+            try {
+                readyItem = readyQueue.poll(tDeadline1 - tNow, TimeUnit.NANOSECONDS);
+            } catch (InterruptedException ex) {
+                LOG.log(Level.INFO, "interrupted while waiting for scrape data", ex);
+                continue;
+            }
+            if (readyItem != null) {
+                readyItem.getLeft().ifPresent(result::addAll);
+                if (readyItem.getRight().isPresent())
+                    ++failCount;
+                --pendingCount;
+            }
+        }
+
+        // Fire timeout event.
+        timeout.complete(new GroupGenerator.TimeoutObject());
+
+        // Collect everything we can get within the grace period.
+        while (pendingCount > 0) {
+            final long tNow = System.nanoTime();
+            if (tDeadline2 - tNow <= 0) break;  // GUARD
+
+            final Any2<Collection<? extends MetricGroup>, Throwable> readyItem;
+            try {
+                readyItem = readyQueue.poll(tDeadline2 - tNow, TimeUnit.NANOSECONDS);
+            } catch (InterruptedException ex) {
+                LOG.log(Level.INFO, "interrupted while waiting for scrape data", ex);
+                continue;
+            }
+            if (readyItem != null) {
+                readyItem.getLeft().ifPresent(result::addAll);
+                if (readyItem.getRight().isPresent())
+                    ++failCount;
+                --pendingCount;
+            }
+        }
+
+        // Collect everything that is present.
+        while (pendingCount > 0) {
+            final Any2<Collection<? extends MetricGroup>, Throwable> readyItem
+                    = readyQueue.poll();
+            if (readyItem == null) break;  // GUARD
+            readyItem.getLeft().ifPresent(result::addAll);
+            if (readyItem.getRight().isPresent())
+                ++failCount;
+            --pendingCount;
+        }
+
+        // Expose failure count.
+        failed_collections_ = pendingCount + failCount;
+        return result;
     }
 
     public synchronized void decorate(TimeSeriesTransformer decorator) {
@@ -173,27 +305,33 @@ public abstract class MetricRegistryInstance implements MetricRegistry, AutoClos
     @Override
     public void close() {
         generators_.forEach((g) -> {
-                    try {
-                        g.close();
-                    } catch (Exception e) {
-                        logger.log(Level.SEVERE, "failed to close group generator " + g, e);
-                    }
-                });
+            try {
+                g.close();
+            } catch (Exception e) {
+                LOG.log(Level.SEVERE, "failed to close group generator " + g, e);
+            }
+        });
         if (api_ instanceof AutoCloseable) {
             try {
-                ((AutoCloseable)api_).close();
+                ((AutoCloseable) api_).close();
             } catch (Exception ex) {
-                logger.log(Level.SEVERE, "unable to close API " + api_.getClass(), ex);
+                LOG.log(Level.SEVERE, "unable to close API " + api_.getClass(), ex);
             }
         }
     }
 
     @Override
-    public boolean hasConfig() { return has_config_; }
-    public DateTime now() { return requireNonNull(now_.get()); }
+    public boolean hasConfig() {
+        return has_config_;
+    }
+
+    public DateTime now() {
+        return requireNonNull(now_.get());
+    }
 
     /**
      * Apply all timeseries decorators.
+     *
      * @param ctx Input timeseries.
      */
     protected void apply_rules_and_decorators_(Context ctx) {
@@ -206,19 +344,19 @@ public abstract class MetricRegistryInstance implements MetricRegistry, AutoClos
 
     public static interface CollectionContext {
         public Consumer<Alert> alertManager();
+
         public MutableTimeSeriesCollectionPair tsdata();
+
         public void commit();
     }
 
     protected abstract CollectionContext beginCollection(DateTime now);
 
     /**
-     * Run an update cycle.
-     * An update cycle consists of:
-     * - gathering raw metrics
-     * - creating a new, minimal context
-     * - applying decorators against the current and previous values
-     * - storing the collection values as the most recent capture
+     * Run an update cycle. An update cycle consists of: - gathering raw metrics
+     * - creating a new, minimal context - applying decorators against the
+     * current and previous values - storing the collection values as the most
+     * recent capture
      */
     public TimeSeriesCollection updateCollection() {
         // Scrape metrics from all collectors.

--- a/impl/src/test/java/com/groupon/lex/metrics/MetricRegistryInstanceTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/MetricRegistryInstanceTest.java
@@ -41,9 +41,9 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.hasItem;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -76,10 +76,12 @@ public class MetricRegistryInstanceTest {
     private MetricRegistryInstance.CollectionContext cctx;
 
     private MetricRegistryInstance create(boolean has_config) {
-        return new MetricRegistryInstance(has_config, (pattern, handler) -> {}) {
+        return new MetricRegistryInstance(has_config, (pattern, handler) -> {
+        }) {
             @Override
             protected MetricRegistryInstance.CollectionContext beginCollection(DateTime now) {
-                when(cctx.alertManager()).thenReturn((Alert alert) -> {});
+                when(cctx.alertManager()).thenReturn((Alert alert) -> {
+                });
                 when(cctx.tsdata()).thenAnswer(new Answer<TimeSeriesCollectionPair>() {
                     @Override
                     public TimeSeriesCollectionPair answer(InvocationOnMock invocation) throws Throwable {
@@ -93,10 +95,12 @@ public class MetricRegistryInstanceTest {
     }
 
     private MetricRegistryInstance create(boolean has_config, DateTime now) {
-        return new MetricRegistryInstance(() -> now, has_config, (pattern, handler) -> {}) {
+        return new MetricRegistryInstance(() -> now, has_config, (pattern, handler) -> {
+        }) {
             @Override
             protected MetricRegistryInstance.CollectionContext beginCollection(DateTime now) {
-                when(cctx.alertManager()).thenReturn((Alert alert) -> {});
+                when(cctx.alertManager()).thenReturn((Alert alert) -> {
+                });
                 when(cctx.tsdata()).thenAnswer(new Answer<TimeSeriesCollectionPair>() {
                     @Override
                     public TimeSeriesCollectionPair answer(InvocationOnMock invocation) throws Throwable {
@@ -136,7 +140,8 @@ public class MetricRegistryInstanceTest {
 
     @Test
     public void generator_handling() throws Exception {
-        when(generator.getGroups()).thenReturn(GroupGenerator.successResult(singleton(new SimpleMetricGroup(GroupName.valueOf("test"), Stream.of(new SimpleMetric(MetricName.valueOf("x"), 17))))));
+        when(generator.getGroups(Mockito.any(), Mockito.any()))
+                .thenReturn(singleton(CompletableFuture.completedFuture(singleton(new SimpleMetricGroup(GroupName.valueOf("test"), Stream.of(new SimpleMetric(MetricName.valueOf("x"), 17)))))));
         final DateTime now = DateTime.now(DateTimeZone.UTC);
 
         try (MetricRegistryInstance mr = create(false, now)) {
@@ -147,7 +152,7 @@ public class MetricRegistryInstanceTest {
                     hasItem(new MutableTimeSeriesValue(now, GroupName.valueOf("test"), singletonMap(MetricName.valueOf("x"), MetricValue.fromIntValue(17)))));
         }
 
-        verify(generator, times(1)).getGroups();
+        verify(generator, times(1)).getGroups(Mockito.any(), Mockito.any());
         verify(generator, times(1)).close();
     }
 
@@ -165,27 +170,17 @@ public class MetricRegistryInstanceTest {
 
     @Test
     public void stream_groups() throws Exception {
-        when(generator.getGroups()).thenReturn(GroupGenerator.successResult(singleton(new SimpleMetricGroup(GroupName.valueOf("test"), Stream.of(new SimpleMetric(MetricName.valueOf("x"), 17))))));
+        when(generator.getGroups(Mockito.any(), Mockito.any()))
+                .thenReturn(singleton(CompletableFuture.completedFuture(singleton(new SimpleMetricGroup(GroupName.valueOf("test"), Stream.of(new SimpleMetric(MetricName.valueOf("x"), 17)))))));
 
         try (MetricRegistryInstance mr = create(false)) {
             mr.add(generator);
             mr.updateCollection();
         }
 
-        verify(generator, times(1)).getGroups();
+        verify(generator, times(1)).getGroups(Mockito.any(), Mockito.any());
         verify(generator, times(1)).close();
         verifyNoMoreInteractions(generator);
-    }
-
-    @Test
-    public void group_names_resolution() throws Exception {
-        when(generator.getGroups()).thenReturn(GroupGenerator.successResult(singleton(new SimpleMetricGroup(GroupName.valueOf("test"), Stream.of(new SimpleMetric(MetricName.valueOf("x"), 17))))));
-
-        try (MetricRegistryInstance mr = create(false)) {
-            mr.add(generator);
-            assertThat(mr.getGroupNames(),
-                    arrayContaining(GroupName.valueOf("test")));
-        }
     }
 
     @Test

--- a/impl/src/test/java/com/groupon/lex/metrics/config/JmxListenerMonitorTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/config/JmxListenerMonitorTest.java
@@ -52,6 +52,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -91,6 +94,7 @@ public class JmxListenerMonitorTest {
      * mri.add(GroupGenerator) adds to this collection.
      */
     private List<GroupGenerator> listeners;
+    private ExecutorService threadpool;
 
     private static JmxBuilder newJmxBuilder(Set<ObjectName> names, NameBoundResolver resolver) {
         JmxBuilder builder = new JmxBuilder();
@@ -118,6 +122,8 @@ public class JmxListenerMonitorTest {
             listeners.add(g);
             return g;
         });
+
+        threadpool = Executors.newSingleThreadExecutor();
     }
 
     @After
@@ -129,6 +135,8 @@ public class JmxListenerMonitorTest {
                 LOG.log(Level.WARNING, "unable to close listener " + g, ex);
             }
         }
+
+        threadpool.shutdownNow();
     }
 
     @Test
@@ -184,7 +192,13 @@ public class JmxListenerMonitorTest {
         when(nbr.resolve()).then(invocation -> Stream.of(NamedResolverMap.EMPTY));
 
         mon_oneName.apply(mri);
-        listeners.forEach(GroupGenerator::getGroups);  // Force creation of JMX collectors
+        listeners.forEach(gg -> {
+            try {
+                gg.getGroups(threadpool, new CompletableFuture<>());  // Force creation of JMX collectors
+            } catch (Exception ex) {
+                // Ignore
+            }
+        });
 
         assertThat(listeners,
                 contains(
@@ -202,7 +216,13 @@ public class JmxListenerMonitorTest {
         when(nbr.resolve()).then(invocation -> Stream.of(NamedResolverMap.EMPTY));
 
         mon_twoNames.apply(mri);
-        listeners.forEach(GroupGenerator::getGroups);  // Force creation of JMX collectors
+        listeners.forEach(gg -> {
+            try {
+                gg.getGroups(threadpool, new CompletableFuture<>());  // Force creation of JMX collectors
+            } catch (Exception ex) {
+                // Ignore
+            }
+        });
 
         assertThat(listeners,
                 contains(
@@ -235,7 +255,13 @@ public class JmxListenerMonitorTest {
         ));
 
         mon_oneName.apply(mri);
-        listeners.forEach(GroupGenerator::getGroups);  // Force creation of JMX collectors
+        listeners.forEach(gg -> {
+            try {
+                gg.getGroups(threadpool, new CompletableFuture<>());  // Force creation of JMX collectors
+            } catch (Exception ex) {
+                // Ignore
+            }
+        });
 
         assertThat(listeners,
                 contains(
@@ -283,7 +309,13 @@ public class JmxListenerMonitorTest {
         ));
 
         mon_twoNames.apply(mri);
-        listeners.forEach(GroupGenerator::getGroups);  // Force creation of JMX collectors
+        listeners.forEach(gg -> {
+            try {
+                gg.getGroups(threadpool, new CompletableFuture<>());  // Force creation of JMX collectors
+            } catch (Exception ex) {
+                // Ignore
+            }
+        });
 
         assertThat(listeners,
                 contains(

--- a/intf/src/main/java/com/groupon/lex/metrics/MetricRegistry.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/MetricRegistry.java
@@ -40,20 +40,16 @@ import com.groupon.lex.metrics.httpd.EndpointRegistration;
 public interface MetricRegistry {
     /**
      * Returns the exposed API.
+     *
      * @return The exposed API.
      */
     public EndpointRegistration getApi();
 
     /**
-     * Return a list of all groups in the registry.
-     * @return All groups currently known by the MetricRegistry.
-     */
-    public GroupName[] getGroupNames();
-
-    /**
      * Tests if the metric registry has a configuration.
-     * @return True if the metric has a configuration,
-     *     or false if the metric registry is unconfigured/uses a default configuration.
+     *
+     * @return True if the metric has a configuration, or false if the metric
+     * registry is unconfigured/uses a default configuration.
      */
     public boolean hasConfig();
 }

--- a/intf/src/main/java/com/groupon/lex/metrics/SynchronousGroupGenerator.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/SynchronousGroupGenerator.java
@@ -1,0 +1,19 @@
+package com.groupon.lex.metrics;
+
+import java.util.Collection;
+import static java.util.Collections.singleton;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+public abstract class SynchronousGroupGenerator implements GroupGenerator {
+    protected abstract Collection<? extends MetricGroup> getGroups(CompletableFuture<TimeoutObject> timeout);
+
+    @Override
+    public final Collection<CompletableFuture<? extends Collection<? extends MetricGroup>>> getGroups(Executor threadpool, CompletableFuture<TimeoutObject> timeout) throws Exception {
+        CompletableFuture<Collection<? extends MetricGroup>> result = CompletableFuture.supplyAsync(() -> getGroups(timeout), threadpool);
+        timeout.thenAccept(timeoutObject -> {
+            result.cancel(true);
+        });
+        return singleton(result);
+    }
+}

--- a/lib/src/main/java/com/groupon/lex/metrics/lib/GCCloseable.java
+++ b/lib/src/main/java/com/groupon/lex/metrics/lib/GCCloseable.java
@@ -16,8 +16,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A wrapper around a closable, that uses an unreachability event by the GC
- * to close the underlying closeable.
+ * A wrapper around a closable, that uses an unreachability event by the GC to
+ * close the underlying closeable.
  */
 public class GCCloseable<T extends AutoCloseable> {
     private static final Logger LOG = Logger.getLogger(GCCloseable.class.getName());
@@ -29,7 +29,7 @@ public class GCCloseable<T extends AutoCloseable> {
         Reference<? extends GCCloseable> ref = cleanup_queue_.remove();
         final AutoCloseable item = instances_.remove(ref);
 
-        assert(item != null);
+        assert (item != null);
         try {
             LOG.log(Level.FINE, "closing {0}", item);
             item.close();
@@ -41,7 +41,7 @@ public class GCCloseable<T extends AutoCloseable> {
     private static void ensure_started_() {
         if (started_.get()) return;
 
-        synchronized(GCCloseable.class) {
+        synchronized (GCCloseable.class) {
             final Thread t = new Thread(() -> {
                 for (;;) {
                     try {
@@ -63,6 +63,10 @@ public class GCCloseable<T extends AutoCloseable> {
     }
 
     private final T value_;
+
+    public GCCloseable() {
+        value_ = null;
+    }
 
     public GCCloseable(T value) {
         value_ = requireNonNull(value);


### PR DESCRIPTION
- Make ``GroupGenerator``s asynchronous.
- To keep easy creation of collectors, the ``SynchronousGroupGenerator`` is an abstract base class for those cases where asynchronous operation is not needed.
- Monsoon currently uses up to 1k threads for IO.