### PR TITLE
Remove unused timestamp property from TimeSeriesValue.

### DIFF
--- a/history/src/main/java/com/groupon/lex/metrics/history/v1/xdr/FromXdr.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v1/xdr/FromXdr.java
@@ -1,6 +1,5 @@
 package com.groupon.lex.metrics.history.v1.xdr;
 
-import com.groupon.lex.metrics.history.xdr.support.ImmutableTimeSeriesValue;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import static com.groupon.lex.metrics.ConfigSupport.quotedString;
@@ -10,6 +9,7 @@ import com.groupon.lex.metrics.MetricName;
 import com.groupon.lex.metrics.MetricValue;
 import com.groupon.lex.metrics.SimpleGroupPath;
 import com.groupon.lex.metrics.Tags;
+import com.groupon.lex.metrics.history.xdr.support.ImmutableTimeSeriesValue;
 import com.groupon.lex.metrics.lib.SimpleMapEntry;
 import com.groupon.lex.metrics.timeseries.SimpleTimeSeriesCollection;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
@@ -35,12 +35,24 @@ public class FromXdr {
     private final BiMap<Integer, MetricName> metric_dict = HashBiMap.create();
     private final BiMap<Integer, MetricValue> strval_dict = HashBiMap.create();
 
-    public FromXdr() {}
+    public FromXdr() {
+    }
 
-    public BiMap<Integer, SimpleGroupPath> getGroupDict() { return group_dict; }
-    public BiMap<Integer, Tags> getTagDict() { return tag_dict; }
-    public BiMap<Integer, MetricName> getMetricDict() { return metric_dict; }
-    public BiMap<Integer, MetricValue> getStrvalDict() { return strval_dict; }
+    public BiMap<Integer, SimpleGroupPath> getGroupDict() {
+        return group_dict;
+    }
+
+    public BiMap<Integer, Tags> getTagDict() {
+        return tag_dict;
+    }
+
+    public BiMap<Integer, MetricName> getMetricDict() {
+        return metric_dict;
+    }
+
+    public BiMap<Integer, MetricValue> getStrvalDict() {
+        return strval_dict;
+    }
 
     public static DateTime timestamp(timestamp_msec ts) {
         return new DateTime(ts.value, DateTimeZone.UTC);
@@ -62,7 +74,7 @@ public class FromXdr {
             case metrickind.HISTOGRAM:
                 return MetricValue.fromHistValue(new Histogram(
                         Arrays.stream(mv.hist_value)
-                                .map(he -> new Histogram.RangeWithCount(he.floor, he.ceil, he.events))));
+                        .map(he -> new Histogram.RangeWithCount(he.floor, he.ceil, he.events))));
         }
     }
 
@@ -92,7 +104,7 @@ public class FromXdr {
                     final MetricValue mvalue = metric_value_(metric.v);
                     return SimpleMapEntry.create(mname, mvalue);
                 });
-        return new ImmutableTimeSeriesValue(ts, GroupName.valueOf(group_name, tags), metrics, Map.Entry::getKey, Map.Entry::getValue);
+        return new ImmutableTimeSeriesValue(GroupName.valueOf(group_name, tags), metrics, Map.Entry::getKey, Map.Entry::getValue);
     }
 
     private void update_dict_(dictionary_delta dd) {

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesCollection.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesCollection.java
@@ -86,7 +86,7 @@ public class RTFTimeSeriesCollection extends AbstractTimeSeriesCollection {
     }
 
     private TimeSeriesValue newTSV(GroupName group, RTFGroupTable table) {
-        return new RTFTimeSeriesValue(timestamp, index, group, table);
+        return new RTFTimeSeriesValue(index, group, table);
     }
 
     @Override

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesValue.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesValue.java
@@ -42,30 +42,21 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 /**
  *
  * @author ariane
  */
 public class RTFTimeSeriesValue extends AbstractTimeSeriesValue {
-    private final long ts;
     private final int index;
     @Getter
     private final GroupName group;
     private final RTFGroupTable tbl;
 
-    public RTFTimeSeriesValue(long ts, int index, GroupName group, RTFGroupTable tbl) {
-        this.ts = ts;
+    public RTFTimeSeriesValue(int index, GroupName group, RTFGroupTable tbl) {
         this.index = index;
         this.group = group;
         this.tbl = tbl;
-    }
-
-    @Override
-    public DateTime getTimestamp() {
-        return new DateTime(ts, DateTimeZone.UTC);
     }
 
     @Override

--- a/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/ImmutableTimeSeriesValue.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/xdr/support/ImmutableTimeSeriesValue.java
@@ -17,20 +17,17 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
-import org.joda.time.DateTime;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ImmutableTimeSeriesValue extends AbstractTimeSeriesValue implements TimeSeriesValue {
     @NonNull
-    private final DateTime timestamp;
-    @NonNull
     private final GroupName group;
     @NonNull
     private final Map<MetricName, MetricValue> metrics;
 
-    public <T> ImmutableTimeSeriesValue(DateTime ts, GroupName group, Stream<T> metrics, Function<? super T, MetricName> name_fn, Function<? super T, MetricValue> value_fn) {
-        this(ts, group, unmodifiableMap(metrics.collect(Collectors.toMap(name_fn, value_fn, throwing_merger_(), hashmap_constructor_()))));
+    public <T> ImmutableTimeSeriesValue(GroupName group, Stream<T> metrics, Function<? super T, MetricName> name_fn, Function<? super T, MetricValue> value_fn) {
+        this(group, unmodifiableMap(metrics.collect(Collectors.toMap(name_fn, value_fn, throwing_merger_(), hashmap_constructor_()))));
     }
 
     @Override
@@ -39,10 +36,15 @@ public final class ImmutableTimeSeriesValue extends AbstractTimeSeriesValue impl
     }
 
     private static <T> BinaryOperator<T> throwing_merger_() {
-        return (x, y) -> { throw new IllegalStateException("duplicate key " + x); };
+        return (x, y) -> {
+            throw new IllegalStateException("duplicate key " + x);
+        };
     }
 
-    /** HashMap constructor, so we can create hashmaps with an altered load factor. */
+    /**
+     * HashMap constructor, so we can create hashmaps with an altered load
+     * factor.
+     */
     private static <K, V> Supplier<Map<K, V>> hashmap_constructor_() {
         return () -> new THashMap<K, V>();
     }

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/TSDataTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/TSDataTest.java
@@ -147,10 +147,10 @@ public class TSDataTest {
                 .map(new Function<Integer, TimeSeriesCollection>() {
                     public TimeSeriesCollection apply(Integer i) {
                         return new SimpleTimeSeriesCollection(now.plusMinutes(i), Stream.of(
-                                new MutableTimeSeriesValue(now.plusMinutes(i),
+                                new MutableTimeSeriesValue(
                                         GroupName.valueOf(SimpleGroupPath.valueOf("foo", "bar")),
                                         singletonMap(MetricName.valueOf("x"), MetricValue.fromIntValue(i))),
-                                new MutableTimeSeriesValue(now.plusMinutes(i),
+                                new MutableTimeSeriesValue(
                                         GroupName.valueOf(SimpleGroupPath.valueOf("h", "i", "s", "t", "o", "g", "r", "a", "m")),
                                         singletonMap(MetricName.valueOf("x"), MetricValue.fromHistValue(hist)))
                         ));

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/UnmappedReadonlyTSDataFileTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/UnmappedReadonlyTSDataFileTest.java
@@ -52,10 +52,10 @@ public class UnmappedReadonlyTSDataFileTest {
     @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
         return Arrays.asList(
-                new Object[]{ new FileSupport(new FileSupport0(), false) },
-                new Object[]{ new FileSupport(new FileSupport1(), false) },
-                new Object[]{ new FileSupport(new FileSupport0(), true) },
-                new Object[]{ new FileSupport(new FileSupport1(), true) }
+                new Object[]{new FileSupport(new FileSupport0(), false)},
+                new Object[]{new FileSupport(new FileSupport1(), false)},
+                new Object[]{new FileSupport(new FileSupport0(), true)},
+                new Object[]{new FileSupport(new FileSupport1(), true)}
         );
     }
 
@@ -70,9 +70,9 @@ public class UnmappedReadonlyTSDataFileTest {
         tsdata = new ArrayList<>();
         for (int i = 0; i < 100; ++i) {
             tsdata.add(new SimpleTimeSeriesCollection(now.plusMinutes(i), Stream.of(
-                new MutableTimeSeriesValue(now.plusMinutes(i),
-                        GroupName.valueOf(SimpleGroupPath.valueOf("foo", "bar")),
-                        singletonMap(MetricName.valueOf("x"), MetricValue.fromIntValue(i))))));
+                    new MutableTimeSeriesValue(
+                            GroupName.valueOf(SimpleGroupPath.valueOf("foo", "bar")),
+                            singletonMap(MetricName.valueOf("x"), MetricValue.fromIntValue(i))))));
         }
 
         expect_reversed = new ArrayList<>(tsdata);

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/XdrReadBackTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/XdrReadBackTest.java
@@ -1,13 +1,16 @@
 package com.groupon.lex.metrics.history.xdr;
 
-import com.groupon.lex.metrics.history.v0.xdr.ToXdr;
-import com.groupon.lex.metrics.history.v0.xdr.FromXdr;
 import com.groupon.lex.metrics.GroupName;
 import com.groupon.lex.metrics.MetricName;
 import com.groupon.lex.metrics.MetricValue;
 import com.groupon.lex.metrics.SimpleGroupPath;
+import com.groupon.lex.metrics.history.v0.xdr.FromXdr;
+import com.groupon.lex.metrics.history.v0.xdr.ToXdr;
 import com.groupon.lex.metrics.history.v0.xdr.tsfile_datapoint;
+import com.groupon.lex.metrics.history.xdr.support.XdrBufferDecodingStream;
+import com.groupon.lex.metrics.history.xdr.support.XdrBufferEncodingStream;
 import com.groupon.lex.metrics.timeseries.MutableTimeSeriesValue;
+import com.groupon.lex.metrics.timeseries.SimpleTimeSeriesCollection;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
 import java.io.IOException;
 import static java.lang.Math.min;
@@ -17,13 +20,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import com.groupon.lex.metrics.history.xdr.support.XdrBufferDecodingStream;
-import com.groupon.lex.metrics.history.xdr.support.XdrBufferEncodingStream;
-import com.groupon.lex.metrics.timeseries.SimpleTimeSeriesCollection;
-import static org.junit.Assert.assertEquals;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +56,7 @@ public class XdrReadBackTest {
             b.get(result, off, rdlen);
             off += rdlen;
         }
-        assert(off == result.length);
+        assert (off == result.length);
         return result;
     }
 
@@ -64,7 +64,9 @@ public class XdrReadBackTest {
         private final byte[] data_;
         private int off_ = 0;
 
-        public ByteArraySupplier(byte data[]) { data_ = data; }
+        public ByteArraySupplier(byte data[]) {
+            data_ = data;
+        }
 
         @Override
         public void load(ByteBuffer buf) {
@@ -83,14 +85,16 @@ public class XdrReadBackTest {
 
     @Before
     public void setup() {
-        final Map<MetricName, MetricValue> metrics = new HashMap<MetricName, MetricValue>() {{
-            put(MetricName.valueOf("boolean"), MetricValue.fromBoolean(true));
-            put(MetricName.valueOf("integer"), MetricValue.fromIntValue(17));
-            put(MetricName.valueOf("float"), MetricValue.fromDblValue(Math.E));
-            put(MetricName.valueOf("string"), MetricValue.fromStrValue("chocoladevla"));
-        }};
+        final Map<MetricName, MetricValue> metrics = new HashMap<MetricName, MetricValue>() {
+            {
+                put(MetricName.valueOf("boolean"), MetricValue.fromBoolean(true));
+                put(MetricName.valueOf("integer"), MetricValue.fromIntValue(17));
+                put(MetricName.valueOf("float"), MetricValue.fromDblValue(Math.E));
+                put(MetricName.valueOf("string"), MetricValue.fromStrValue("chocoladevla"));
+            }
+        };
         final DateTime now = DateTime.now(DateTimeZone.UTC);
-        tsv_ = new SimpleTimeSeriesCollection(now, Stream.of(new MutableTimeSeriesValue(now, GroupName.valueOf(GROUP), metrics)));
+        tsv_ = new SimpleTimeSeriesCollection(now, Stream.of(new MutableTimeSeriesValue(GroupName.valueOf(GROUP), metrics)));
     }
 
     @Test
@@ -101,12 +105,12 @@ public class XdrReadBackTest {
         encoder.endEncoding();
         byte[] result = to_byte_array(encoder.getBuffers());
 
-        assertArrayEquals(new byte[]{ 0, 0, 0, 17 }, result);
+        assertArrayEquals(new byte[]{0, 0, 0, 17}, result);
     }
 
     @Test
     public void int_deserialized() throws Exception {
-        XdrBufferDecodingStream decoder = new XdrBufferDecodingStream(new ByteArraySupplier(new byte[]{ 0, 0, 0, 19 }));
+        XdrBufferDecodingStream decoder = new XdrBufferDecodingStream(new ByteArraySupplier(new byte[]{0, 0, 0, 19}));
         int result = decoder.xdrDecodeInt();
 
         assertEquals(19, result);

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/FileSupport.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/FileSupport.java
@@ -36,15 +36,21 @@ import org.joda.time.DateTimeZone;
 
 /**
  * Utilities for creating and compressing TSData files.
+ *
  * @author ariane
  */
 @RequiredArgsConstructor
 public class FileSupport {
     public static interface Writer {
         public void create_file(Releaseable<FileChannel> fd, Collection<? extends TimeSeriesCollection> tsdata, boolean compress) throws IOException;
+
         public short getMajor();
+
         public short getMinor();
-        public default boolean isEmptyAllowed() { return true; }
+
+        public default boolean isEmptyAllowed() {
+            return true;
+        }
     }
 
     public static final Writer NO_WRITER = new Writer() {
@@ -70,11 +76,21 @@ public class FileSupport {
     private final boolean compressed;
     public final DateTime NOW = new DateTime(DateTimeZone.UTC);
 
-    public short getMajor() { return writer.getMajor(); }
-    public short getMinor() { return writer.getMinor(); }
-    public boolean isEmptyAllowed() { return writer.isEmptyAllowed(); }
+    public short getMajor() {
+        return writer.getMajor();
+    }
 
-    /** Create a file. */
+    public short getMinor() {
+        return writer.getMinor();
+    }
+
+    public boolean isEmptyAllowed() {
+        return writer.isEmptyAllowed();
+    }
+
+    /**
+     * Create a file.
+     */
     public void create_file(Path file, Collection<? extends TimeSeriesCollection> tsdata) throws IOException {
         try (Releaseable<FileChannel> fd = new Releaseable<>(FileChannel.open(file, READ, WRITE, CREATE))) {
             writer.create_file(fd, tsdata, compressed);
@@ -84,9 +100,11 @@ public class FileSupport {
         }
     }
 
-    /** Generates an endless stream of TimeSeriesCollections. */
+    /**
+     * Generates an endless stream of TimeSeriesCollections.
+     */
     public StreamedCollection<TimeSeriesCollection> create_tsdata(int width) {
-        int metric_width = (int)sqrt(width) + 1;
+        int metric_width = (int) sqrt(width) + 1;
         int group_width = (width + metric_width - 1) / metric_width;
 
         final SimpleGroupPath base_path = SimpleGroupPath.valueOf("foo", "bar");
@@ -108,7 +126,6 @@ public class FileSupport {
                     final Stream<TimeSeriesValue> tsv_stream = group_names.stream()
                             .map(name -> {
                                 return new MutableTimeSeriesValue(
-                                        now,
                                         name,
                                         metric_names.stream(),
                                         Function.identity(),

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/XdrStreamIteratorTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/support/XdrStreamIteratorTest.java
@@ -46,8 +46,8 @@ public class XdrStreamIteratorTest {
     @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
         return Arrays.asList(
-                new Object[]{ new FileSupport(new FileSupport0(), false) },
-                new Object[]{ new FileSupport(new FileSupport1(), false) }
+                new Object[]{new FileSupport(new FileSupport0(), false)},
+                new Object[]{new FileSupport(new FileSupport1(), false)}
         );
     }
 
@@ -62,9 +62,9 @@ public class XdrStreamIteratorTest {
         tsdata = new ArrayList<>();
         for (int i = 0; i < 100; ++i) {
             tsdata.add(new SimpleTimeSeriesCollection(now.plusMinutes(i), Stream.of(
-                new MutableTimeSeriesValue(now.plusMinutes(i),
-                        GroupName.valueOf(SimpleGroupPath.valueOf("foo", "bar")),
-                        singletonMap(MetricName.valueOf("x"), MetricValue.fromIntValue(i))))));
+                    new MutableTimeSeriesValue(
+                            GroupName.valueOf(SimpleGroupPath.valueOf("foo", "bar")),
+                            singletonMap(MetricName.valueOf("x"), MetricValue.fromIntValue(i))))));
         }
 
         tmpdir = Files.createTempDirectory("monsoon-XdrStreamIteratorTest");

--- a/impl/src/main/java/com/groupon/lex/metrics/MetricRegistryInstance.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/MetricRegistryInstance.java
@@ -92,7 +92,9 @@ public abstract class MetricRegistryInstance implements MetricRegistry, AutoClos
     }
 
     @Override
-    public EndpointRegistration getApi() { return api_; }
+    public EndpointRegistration getApi() {
+        return api_;
+    }
 
     public synchronized GroupGenerator add(GroupGenerator g) {
         generators_.add(g);
@@ -104,30 +106,50 @@ public abstract class MetricRegistryInstance implements MetricRegistry, AutoClos
     }
 
     /**
-     * Retrieve the number of collectors that encountered a failure during the last call to streamGroups().
+     * Retrieve the number of collectors that encountered a failure during the
+     * last call to streamGroups().
+     *
      * @return The number of collectors that failed.
      */
-    public long getFailedCollections() { return failed_collections_; }
+    public long getFailedCollections() {
+        return failed_collections_;
+    }
+
     /**
      * Retrieve timing for scrape.
+     *
      * @return The duration it took to complete all scrapes.
      */
-    public Optional<Duration> getScrapeDuration() { return scrape_duration_; }
+    public Optional<Duration> getScrapeDuration() {
+        return scrape_duration_;
+    }
+
     /**
      * Retrieve timing for rule evaluation.
+     *
      * @return The duration it took to evaluate all rules.
      */
-    public Optional<Duration> getRuleEvalDuration() { return rule_eval_duration_; }
+    public Optional<Duration> getRuleEvalDuration() {
+        return rule_eval_duration_;
+    }
+
     /**
      * Retrieve timing for processor to handle the data.
+     *
      * @return The duration it took for the processor, to push all the data out.
      */
-    public Optional<Duration> getProcessorDuration() { return processor_duration_; }
+    public Optional<Duration> getProcessorDuration() {
+        return processor_duration_;
+    }
+
     /**
      * Update the processor duration.
+     *
      * @param duration The time spent in the processor.
      */
-    public void updateProcessorDuration(Duration duration) { processor_duration_ = Optional.of(duration); }
+    public void updateProcessorDuration(Duration duration) {
+        processor_duration_ = Optional.of(duration);
+    }
 
     private Stream<TimeSeriesValue> streamGroups() {
         return streamGroups(now());
@@ -151,10 +173,10 @@ public abstract class MetricRegistryInstance implements MetricRegistry, AutoClos
         Stream<TimeSeriesValue> groups = collections.stream()
                 .map(GroupGenerator.GroupCollection::getGroups)
                 .flatMap(Collection::stream)
-                .collect(Collectors.toMap(MetricGroup::getName, Function.identity(), (x, y) -> y))  // Resolve group-name conflict, such that latest metric wins.
+                .collect(Collectors.toMap(MetricGroup::getName, Function.identity(), (x, y) -> y)) // Resolve group-name conflict, such that latest metric wins.
                 .values()
                 .stream()
-                .map((mg) -> new MutableTimeSeriesValue(now, mg.getName(), Arrays.stream(mg.getMetrics()), Metric::getName, Metric::getValue));
+                .map((mg) -> new MutableTimeSeriesValue(mg.getName(), Arrays.stream(mg.getMetrics()), Metric::getName, Metric::getValue));
         return groups;
     }
 
@@ -173,15 +195,15 @@ public abstract class MetricRegistryInstance implements MetricRegistry, AutoClos
     @Override
     public void close() {
         generators_.forEach((g) -> {
-                    try {
-                        g.close();
-                    } catch (Exception e) {
-                        logger.log(Level.SEVERE, "failed to close group generator " + g, e);
-                    }
-                });
+            try {
+                g.close();
+            } catch (Exception e) {
+                logger.log(Level.SEVERE, "failed to close group generator " + g, e);
+            }
+        });
         if (api_ instanceof AutoCloseable) {
             try {
-                ((AutoCloseable)api_).close();
+                ((AutoCloseable) api_).close();
             } catch (Exception ex) {
                 logger.log(Level.SEVERE, "unable to close API " + api_.getClass(), ex);
             }
@@ -189,11 +211,17 @@ public abstract class MetricRegistryInstance implements MetricRegistry, AutoClos
     }
 
     @Override
-    public boolean hasConfig() { return has_config_; }
-    public DateTime now() { return requireNonNull(now_.get()); }
+    public boolean hasConfig() {
+        return has_config_;
+    }
+
+    public DateTime now() {
+        return requireNonNull(now_.get());
+    }
 
     /**
      * Apply all timeseries decorators.
+     *
      * @param ctx Input timeseries.
      */
     protected void apply_rules_and_decorators_(Context ctx) {
@@ -206,19 +234,19 @@ public abstract class MetricRegistryInstance implements MetricRegistry, AutoClos
 
     public static interface CollectionContext {
         public Consumer<Alert> alertManager();
+
         public MutableTimeSeriesCollectionPair tsdata();
+
         public void commit();
     }
 
     protected abstract CollectionContext beginCollection(DateTime now);
 
     /**
-     * Run an update cycle.
-     * An update cycle consists of:
-     * - gathering raw metrics
-     * - creating a new, minimal context
-     * - applying decorators against the current and previous values
-     * - storing the collection values as the most recent capture
+     * Run an update cycle. An update cycle consists of: - gathering raw metrics
+     * - creating a new, minimal context - applying decorators against the
+     * current and previous values - storing the collection values as the most
+     * recent capture
      */
     public TimeSeriesCollection updateCollection() {
         // Scrape metrics from all collectors.

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollection.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollection.java
@@ -70,7 +70,7 @@ public class MutableTimeSeriesCollection extends AbstractTimeSeriesCollection im
         final Optional<MutableTimeSeriesValue> removed = Optional.ofNullable(data_.put(name, tsv));
         removed.ifPresent(r -> {
             final boolean is_removed = data_by_path_.get(path).remove(r);
-            assert(is_removed);
+            assert (is_removed);
         });
         data_by_path_.computeIfAbsent(path, (p) -> new HashSet<>())
                 .add(tsv);
@@ -83,7 +83,7 @@ public class MutableTimeSeriesCollection extends AbstractTimeSeriesCollection im
         removed.ifPresent(r -> {
             Set<MutableTimeSeriesValue> set = data_by_path_.get(path);
             final boolean is_removed = set.remove(r);
-            assert(is_removed);
+            assert (is_removed);
             if (set.isEmpty())
                 data_by_path_.remove(path);
         });
@@ -129,7 +129,7 @@ public class MutableTimeSeriesCollection extends AbstractTimeSeriesCollection im
     public TimeSeriesCollection addMetrics(GroupName group, Map<MetricName, MetricValue> metrics) {
         final Optional<MutableTimeSeriesValue> opt_tsv = remove_(group);  // Unlink, since we may alter the hash bucket.
         if (!opt_tsv.isPresent()) {
-            add_(new MutableTimeSeriesValue(getTimestamp(), group, metrics));
+            add_(new MutableTimeSeriesValue(group, metrics));
         } else {
             final MutableTimeSeriesValue tsv = opt_tsv.get();
             tsv.addMetrics(metrics);
@@ -139,7 +139,9 @@ public class MutableTimeSeriesCollection extends AbstractTimeSeriesCollection im
     }
 
     @Override
-    public DateTime getTimestamp() { return timestamp_; }
+    public DateTime getTimestamp() {
+        return timestamp_;
+    }
 
     public MutableTimeSeriesCollection setTimestamp(DateTime timestamp) {
         timestamp_ = requireNonNull(timestamp);
@@ -147,7 +149,9 @@ public class MutableTimeSeriesCollection extends AbstractTimeSeriesCollection im
     }
 
     @Override
-    public boolean isEmpty() { return data_.isEmpty(); }
+    public boolean isEmpty() {
+        return data_.isEmpty();
+    }
 
     @Override
     public Set<GroupName> getGroups() {

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesValue.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesValue.java
@@ -40,44 +40,30 @@ import java.util.Map;
 import static java.util.Objects.requireNonNull;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import org.joda.time.DateTime;
 
 /**
  *
  * @author ariane
  */
 public final class MutableTimeSeriesValue extends AbstractTimeSeriesValue implements TimeSeriesValue {
-    private DateTime timestamp_;
     private GroupName group_;
     private final Map<MetricName, MetricValue> metrics_ = new THashMap<>(4, 1);  // Favour small, dense hashmaps, since there are a lot of instances.
 
-    public MutableTimeSeriesValue(DateTime timestamp, GroupName group) {
-        timestamp_ = requireNonNull(timestamp);
+    public MutableTimeSeriesValue(GroupName group) {
         group_ = requireNonNull(group);
     }
 
-    public MutableTimeSeriesValue(DateTime timestamp, GroupName group, Map<? extends MetricName, ? extends MetricValue> metrics) {
-        this(timestamp, group, metrics.entrySet().stream(), Map.Entry::getKey, Map.Entry::getValue);
+    public MutableTimeSeriesValue(GroupName group, Map<? extends MetricName, ? extends MetricValue> metrics) {
+        this(group, metrics.entrySet().stream(), Map.Entry::getKey, Map.Entry::getValue);
     }
 
-    public <T> MutableTimeSeriesValue(DateTime timestamp, GroupName group, Stream<T> metric_stream, Function<T, MetricName> name_fn, Function<T, MetricValue> value_fn) {
-        timestamp_ = requireNonNull(timestamp);
+    public <T> MutableTimeSeriesValue(GroupName group, Stream<T> metric_stream, Function<T, MetricName> name_fn, Function<T, MetricValue> value_fn) {
         group_ = requireNonNull(group);
         metric_stream.forEach((T t) -> metrics_.put(requireNonNull(name_fn.apply(t)), requireNonNull(value_fn.apply(t))));
     }
 
     public MutableTimeSeriesValue(TimeSeriesValue tsv) {
-        this(tsv.getTimestamp(), tsv.getGroup(), tsv.getMetrics());
-    }
-
-    @Override
-    public DateTime getTimestamp() {
-        return timestamp_;
-    }
-
-    public MutableTimeSeriesValue setTimestamp(DateTime timestamp) {
-        timestamp_ = requireNonNull(timestamp);
-        return this;
+        this(tsv.getGroup(), tsv.getMetrics());
     }
 
     @Override

--- a/impl/src/test/java/com/groupon/lex/metrics/MetricRegistryInstanceTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/MetricRegistryInstanceTest.java
@@ -76,10 +76,12 @@ public class MetricRegistryInstanceTest {
     private MetricRegistryInstance.CollectionContext cctx;
 
     private MetricRegistryInstance create(boolean has_config) {
-        return new MetricRegistryInstance(has_config, (pattern, handler) -> {}) {
+        return new MetricRegistryInstance(has_config, (pattern, handler) -> {
+        }) {
             @Override
             protected MetricRegistryInstance.CollectionContext beginCollection(DateTime now) {
-                when(cctx.alertManager()).thenReturn((Alert alert) -> {});
+                when(cctx.alertManager()).thenReturn((Alert alert) -> {
+                });
                 when(cctx.tsdata()).thenAnswer(new Answer<TimeSeriesCollectionPair>() {
                     @Override
                     public TimeSeriesCollectionPair answer(InvocationOnMock invocation) throws Throwable {
@@ -93,10 +95,12 @@ public class MetricRegistryInstanceTest {
     }
 
     private MetricRegistryInstance create(boolean has_config, DateTime now) {
-        return new MetricRegistryInstance(() -> now, has_config, (pattern, handler) -> {}) {
+        return new MetricRegistryInstance(() -> now, has_config, (pattern, handler) -> {
+        }) {
             @Override
             protected MetricRegistryInstance.CollectionContext beginCollection(DateTime now) {
-                when(cctx.alertManager()).thenReturn((Alert alert) -> {});
+                when(cctx.alertManager()).thenReturn((Alert alert) -> {
+                });
                 when(cctx.tsdata()).thenAnswer(new Answer<TimeSeriesCollectionPair>() {
                     @Override
                     public TimeSeriesCollectionPair answer(InvocationOnMock invocation) throws Throwable {
@@ -144,7 +148,7 @@ public class MetricRegistryInstanceTest {
             List<TimeSeriesValue> sgroups = mr.updateCollection().getTSValues().stream().collect(Collectors.toList());
 
             assertThat(sgroups,
-                    hasItem(new MutableTimeSeriesValue(now, GroupName.valueOf("test"), singletonMap(MetricName.valueOf("x"), MetricValue.fromIntValue(17)))));
+                    hasItem(new MutableTimeSeriesValue(GroupName.valueOf("test"), singletonMap(MetricName.valueOf("x"), MetricValue.fromIntValue(17)))));
         }
 
         verify(generator, times(1)).getGroups();

--- a/impl/src/test/java/com/groupon/lex/metrics/config/ResolvedConstantStatementTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/config/ResolvedConstantStatementTest.java
@@ -48,8 +48,6 @@ import static java.util.Collections.EMPTY_MAP;
 import static java.util.Collections.singletonMap;
 import java.util.HashMap;
 import java.util.stream.Stream;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -74,20 +72,24 @@ public class ResolvedConstantStatementTest {
 
     private final ResolvedConstantStatement stmt_multi = new ResolvedConstantStatement(
             new LiteralGroupExpression(new LiteralNameResolver("foo")),
-            new HashMap<NameResolver, MetricValue>() {{
-                put(new LiteralNameResolver("x"), MetricValue.fromIntValue(17));
-                put(new LiteralNameResolver("y"), MetricValue.fromIntValue(19));
-            }});
+            new HashMap<NameResolver, MetricValue>() {
+        {
+            put(new LiteralNameResolver("x"), MetricValue.fromIntValue(17));
+            put(new LiteralNameResolver("y"), MetricValue.fromIntValue(19));
+        }
+    });
 
     private final ResolvedConstantStatement copy_of_stmt_single = new ResolvedConstantStatement(
             new LiteralGroupExpression(new LiteralNameResolver("foo")),
             singletonMap(new LiteralNameResolver("x"), MetricValue.fromIntValue(17)));
     private final ResolvedConstantStatement copy_of_stmt_multi = new ResolvedConstantStatement(
             new LiteralGroupExpression(new LiteralNameResolver("foo")),
-            new HashMap<NameResolver, MetricValue>() {{
-                put(new LiteralNameResolver("x"), MetricValue.fromIntValue(17));
-                put(new LiteralNameResolver("y"), MetricValue.fromIntValue(19));
-            }});
+            new HashMap<NameResolver, MetricValue>() {
+        {
+            put(new LiteralNameResolver("x"), MetricValue.fromIntValue(17));
+            put(new LiteralNameResolver("y"), MetricValue.fromIntValue(19));
+        }
+    });
     private final ResolvedConstantStatement copy_of_stmt_single_with_other_group = new ResolvedConstantStatement(
             new LiteralGroupExpression(new LiteralNameResolver("bar")),
             singletonMap(new LiteralNameResolver("x"), MetricValue.fromIntValue(17)));
@@ -101,15 +103,15 @@ public class ResolvedConstantStatementTest {
     @Mock
     private Context<MutableTimeSeriesCollectionPair> ctx;
 
-    private final TimeSeriesValue tsv = new MutableTimeSeriesValue(DateTime.now(DateTimeZone.UTC), GroupName.valueOf("foo"), EMPTY_MAP);
+    private final TimeSeriesValue tsv = new MutableTimeSeriesValue(GroupName.valueOf("foo"), EMPTY_MAP);
 
     @Test
     public void config_string() {
         assertEquals("constant foo x 17;\n", stmt_single.configString().toString());
         assertEquals("constant foo {\n"
-                   + "  x 17;\n"
-                   + "  y 19;\n"
-                   + "}\n",
+                + "  x 17;\n"
+                + "  y 19;\n"
+                + "}\n",
                 stmt_multi.configString().toString());
     }
 

--- a/impl/src/test/java/com/groupon/lex/metrics/expression/IdentifierGroupExpressionTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/expression/IdentifierGroupExpressionTest.java
@@ -39,8 +39,6 @@ import com.groupon.lex.metrics.timeseries.expression.Context;
 import java.util.Optional;
 import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.containsString;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -61,7 +59,7 @@ public class IdentifierGroupExpressionTest {
     @Mock
     private Context ctx;
 
-    private TimeSeriesValue tsv = new MutableTimeSeriesValue(DateTime.now(DateTimeZone.UTC), GroupName.valueOf("foobar"));
+    private TimeSeriesValue tsv = new MutableTimeSeriesValue(GroupName.valueOf("foobar"));
 
     @Test
     public void config_string() {

--- a/impl/src/test/java/com/groupon/lex/metrics/expression/LiteralGroupExpressionTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/expression/LiteralGroupExpressionTest.java
@@ -43,8 +43,6 @@ import com.groupon.lex.metrics.transformers.NameResolver;
 import java.util.Optional;
 import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.containsString;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -69,7 +67,7 @@ public class LiteralGroupExpressionTest {
     @Mock
     private TimeSeriesCollectionPair ts_data;
 
-    private TimeSeriesValue tsv = new MutableTimeSeriesValue(DateTime.now(DateTimeZone.UTC), GroupName.valueOf("foobar"));
+    private TimeSeriesValue tsv = new MutableTimeSeriesValue(GroupName.valueOf("foobar"));
 
     @Test
     public void name() {

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/InterpolatedTSCTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/InterpolatedTSCTest.java
@@ -81,8 +81,6 @@ public class InterpolatedTSCTest {
         when(presentValue.getGroup()).thenReturn(TESTGROUP);
         when(pastValue.getTags()).thenReturn(TESTGROUP.getTags());
         when(futureValue.getTags()).thenReturn(TESTGROUP.getTags());
-        when(pastValue.getTimestamp()).thenReturn(pastDate);
-        when(futureValue.getTimestamp()).thenReturn(futureDate);
         when(pastValue.findMetric(Mockito.any())).thenCallRealMethod();
         when(futureValue.findMetric(Mockito.any())).thenCallRealMethod();
 
@@ -99,7 +97,6 @@ public class InterpolatedTSCTest {
 
         assertTrue(interpolatedTSC.get(TESTGROUP).isPresent());
         assertEquals(TESTGROUP, interpolatedTSC.get(TESTGROUP).get().getGroup());
-        assertEquals(midDate, interpolatedTSC.get(TESTGROUP).get().getTimestamp());
         assertEquals(Optional.of(MetricValue.fromDblValue(0.25)), interpolatedTSC.get(TESTGROUP).get().findMetric(TESTMETRIC));
     }
 
@@ -112,7 +109,6 @@ public class InterpolatedTSCTest {
 
         assertTrue(interpolatedTSC.get(TESTGROUP).isPresent());
         assertEquals(TESTGROUP, interpolatedTSC.get(TESTGROUP).get().getGroup());
-        assertEquals(midDate, interpolatedTSC.get(TESTGROUP).get().getTimestamp());
         assertEquals(Optional.of(MetricValue.fromDblValue(5)), interpolatedTSC.get(TESTGROUP).get().findMetric(TESTMETRIC));
     }
 
@@ -125,7 +121,6 @@ public class InterpolatedTSCTest {
 
         assertTrue(interpolatedTSC.get(TESTGROUP).isPresent());
         assertEquals(TESTGROUP, interpolatedTSC.get(TESTGROUP).get().getGroup());
-        assertEquals(midDate, interpolatedTSC.get(TESTGROUP).get().getTimestamp());
         assertEquals(Optional.of(MetricValue.fromDblValue(5.9)), interpolatedTSC.get(TESTGROUP).get().findMetric(TESTMETRIC));
     }
 
@@ -138,7 +133,6 @@ public class InterpolatedTSCTest {
 
         assertTrue(interpolatedTSC.get(TESTGROUP).isPresent());
         assertEquals(TESTGROUP, interpolatedTSC.get(TESTGROUP).get().getGroup());
-        assertEquals(midDate, interpolatedTSC.get(TESTGROUP).get().getTimestamp());
         assertEquals(Optional.of(MetricValue.fromStrValue("foo")), interpolatedTSC.get(TESTGROUP).get().findMetric(TESTMETRIC));
     }
 
@@ -151,13 +145,12 @@ public class InterpolatedTSCTest {
 
         assertTrue(interpolatedTSC.get(TESTGROUP).isPresent());
         assertEquals(TESTGROUP, interpolatedTSC.get(TESTGROUP).get().getGroup());
-        assertEquals(midDate, interpolatedTSC.get(TESTGROUP).get().getTimestamp());
         assertEquals(Optional.of(MetricValue.fromHistValue(new Histogram(new RangeWithCount(0, 10, 5)))), interpolatedTSC.get(TESTGROUP).get().findMetric(TESTMETRIC));
     }
 
     @Test
     public void namesFromBothArePresent() {
-        TimeSeriesCollection present = new SimpleTimeSeriesCollection(midDate, singletonList(new MutableTimeSeriesValue(midDate, GroupName.valueOf("mid", "point"))));
+        TimeSeriesCollection present = new SimpleTimeSeriesCollection(midDate, singletonList(new MutableTimeSeriesValue(GroupName.valueOf("mid", "point"))));
         InterpolatedTSC interpolatedTSC = new InterpolatedTSC(present, singletonList(past), singletonList(future));
 
         assertThat(interpolatedTSC.getGroups(),
@@ -203,7 +196,7 @@ public class InterpolatedTSCTest {
         when(pastValue.getMetrics()).thenReturn(singletonMap(TESTMETRIC, MetricValue.fromIntValue(4)));
         when(futureValue.getMetrics()).thenReturn(singletonMap(TESTMETRIC, MetricValue.fromIntValue(8)));
 
-        final TimeSeriesCollection expected = new SimpleTimeSeriesCollection(midDate, singletonList(new MutableTimeSeriesValue(midDate, TESTGROUP, singletonMap(TESTMETRIC, MetricValue.fromDblValue(5)))));
+        final TimeSeriesCollection expected = new SimpleTimeSeriesCollection(midDate, singletonList(new MutableTimeSeriesValue(TESTGROUP, singletonMap(TESTMETRIC, MetricValue.fromDblValue(5)))));
         InterpolatedTSC interpolatedTSC = new InterpolatedTSC(new EmptyTimeSeriesCollection(midDate), singletonList(past), singletonList(future));
 
         assertEquals(expected.hashCode(), interpolatedTSC.hashCode());

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollectionTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollectionTest.java
@@ -60,8 +60,8 @@ public class MutableTimeSeriesCollectionTest {
     private static final DateTime t0 = new DateTime(2015, 10, 21, 11, 28, 7, DateTimeZone.UTC);
     private static final DateTime t0_ts = t0.minus(Duration.standardSeconds(5));
     private static final SimpleGroupPath group_name = SimpleGroupPath.valueOf("com", "groupon", "lex", "jmx-monitord", "Awesomoium");
-    private static final MutableTimeSeriesValue ts_value = new MutableTimeSeriesValue(t0_ts, GroupName.valueOf(group_name, EMPTY_MAP), singletonMap(ts_metric_value__name, ts_metric_value__value));
-    private static final MutableTimeSeriesValue absent_value = new MutableTimeSeriesValue(t0, GroupName.valueOf("not", "here"), singletonMap(MetricName.valueOf("foo"), MetricValue.TRUE));
+    private static final MutableTimeSeriesValue ts_value = new MutableTimeSeriesValue(GroupName.valueOf(group_name, EMPTY_MAP), singletonMap(ts_metric_value__name, ts_metric_value__value));
+    private static final MutableTimeSeriesValue absent_value = new MutableTimeSeriesValue(GroupName.valueOf("not", "here"), singletonMap(MetricName.valueOf("foo"), MetricValue.TRUE));
 
     @Test
     public void constructor() {
@@ -79,7 +79,7 @@ public class MutableTimeSeriesCollectionTest {
 
         assertEquals(t0, ts_data.getTimestamp());
         assertThat(ts_data.getTSValues().stream()
-                        .collect(Collectors.toList()),
+                .collect(Collectors.toList()),
                 hasItem(ts_value));
         assertThat(ts_data.getGroups(),
                 hasItem(GroupName.valueOf(group_name, EMPTY_MAP)));
@@ -130,10 +130,10 @@ public class MutableTimeSeriesCollectionTest {
     @Test
     public void overwrite_existing_group() {
         MutableTimeSeriesCollection ts_data = new MutableTimeSeriesCollection(t0, Stream.of(ts_value));
-        ts_data.add(new MutableTimeSeriesValue(t0, GroupName.valueOf(group_name), singletonMap(MetricName.valueOf("foo"), MetricValue.fromStrValue("bar"))));
+        ts_data.add(new MutableTimeSeriesValue(GroupName.valueOf(group_name), singletonMap(MetricName.valueOf("foo"), MetricValue.fromStrValue("bar"))));
 
         assertThat(ts_data.getTSValue(group_name).stream().collect(Collectors.toList()),
-                hasItem(new MutableTimeSeriesValue(t0, GroupName.valueOf(group_name), singletonMap(MetricName.valueOf("foo"), MetricValue.fromStrValue("bar")))));
+                hasItem(new MutableTimeSeriesValue(GroupName.valueOf(group_name), singletonMap(MetricName.valueOf("foo"), MetricValue.fromStrValue("bar")))));
     }
 
     @Test
@@ -144,23 +144,23 @@ public class MutableTimeSeriesCollectionTest {
 
         assertTrue(!group.isEmpty());
         assertThat(group.findMetric(MetricName.valueOf("foo")).streamValues()
-                        .collect(Collectors.toList()),
+                .collect(Collectors.toList()),
                 hasItem(MetricValue.fromStrValue("bar")));
         assertThat(group.findMetric(ts_metric_value__name).streamValues()
-                        .collect(Collectors.toList()),
+                .collect(Collectors.toList()),
                 hasItem(ts_metric_value__value));
     }
 
     @Test
     public void rename_group() {
         MutableTimeSeriesCollection ts_data = new MutableTimeSeriesCollection(t0, Stream.of(ts_value));
-        final TimeSeriesValue EXPECT_TS_AFTER_RENAME = new MutableTimeSeriesValue(t0_ts, GroupName.valueOf("post", "rename"), singletonMap(ts_metric_value__name, ts_metric_value__value));
+        final TimeSeriesValue EXPECT_TS_AFTER_RENAME = new MutableTimeSeriesValue(GroupName.valueOf("post", "rename"), singletonMap(ts_metric_value__name, ts_metric_value__value));
 
         ts_data.renameGroup(GroupName.valueOf(group_name), GroupName.valueOf("post", "rename"));
 
         assertEquals(t0, ts_data.getTimestamp());
         assertThat(ts_data.getTSValues().stream()
-                        .collect(Collectors.toList()),
+                .collect(Collectors.toList()),
                 hasItem(EXPECT_TS_AFTER_RENAME));
         assertThat(ts_data.getGroups(),
                 hasItem(GroupName.valueOf("post", "rename")));

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesValueSetTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesValueSetTest.java
@@ -59,8 +59,8 @@ public class MutableTimeSeriesValueSetTest {
     private static final GroupName group_name = GroupName.valueOf("foo", "bar");
     private static final SimpleGroupPath group_path = SimpleGroupPath.valueOf("foo", "bar");
     private static final Map<MetricName, MetricValue> values = singletonMap(metric_key, metric_value);
-    private static final TimeSeriesValue tsv0 = new MutableTimeSeriesValue(t0, group_name, values);
-    private final static TimeSeriesValue tsv1 = new MutableTimeSeriesValue(t0, GroupName.valueOf(group_name.getPath(), singletonMap("x", MetricValue.TRUE)), values);
+    private static final TimeSeriesValue tsv0 = new MutableTimeSeriesValue(group_name, values);
+    private final static TimeSeriesValue tsv1 = new MutableTimeSeriesValue(GroupName.valueOf(group_name.getPath(), singletonMap("x", MetricValue.TRUE)), values);
 
     @Test
     public void empty_constructor() {

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesValueTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesValueTest.java
@@ -42,7 +42,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.Duration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -60,9 +59,8 @@ public class MutableTimeSeriesValueTest {
 
     @Test
     public void constructor() {
-        TimeSeriesValue tsv = new MutableTimeSeriesValue(t0, group_name, values);
+        TimeSeriesValue tsv = new MutableTimeSeriesValue(group_name, values);
 
-        assertEquals(t0, tsv.getTimestamp());
         assertEquals(group_name, tsv.getGroup());
         assertEquals(new HashMap<>(values), new HashMap<>(tsv.getMetrics()));
         assertEquals(Optional.of(MetricValue.fromIntValue(7)), tsv.findMetric(metric_key));
@@ -70,9 +68,8 @@ public class MutableTimeSeriesValueTest {
 
     @Test
     public void constructor_from_stream() {
-        TimeSeriesValue tsv = new MutableTimeSeriesValue(t0, group_name, Stream.of(new Object()), (xx) -> metric_key, (xx) -> MetricValue.fromIntValue(7));
+        TimeSeriesValue tsv = new MutableTimeSeriesValue(group_name, Stream.of(new Object()), (xx) -> metric_key, (xx) -> MetricValue.fromIntValue(7));
 
-        assertEquals(t0, tsv.getTimestamp());
         assertEquals(group_name, tsv.getGroup());
         assertEquals(new HashMap<>(values), new HashMap<>(tsv.getMetrics()));
         assertEquals(Optional.of(MetricValue.fromIntValue(7)), tsv.findMetric(metric_key));
@@ -80,8 +77,8 @@ public class MutableTimeSeriesValueTest {
 
     @Test
     public void equality() {
-        TimeSeriesValue x = new MutableTimeSeriesValue(t0, group_name, values);
-        TimeSeriesValue y = new MutableTimeSeriesValue(t0, group_name, Stream.of(new Object()), (xx) -> metric_key, (xx) -> MetricValue.fromIntValue(7));
+        TimeSeriesValue x = new MutableTimeSeriesValue(group_name, values);
+        TimeSeriesValue y = new MutableTimeSeriesValue(group_name, Stream.of(new Object()), (xx) -> metric_key, (xx) -> MetricValue.fromIntValue(7));
 
         assertTrue(x.hashCode() == y.hashCode());
         assertTrue(x.equals(y));
@@ -89,20 +86,18 @@ public class MutableTimeSeriesValueTest {
 
     @Test
     public void inequality() {
-        TimeSeriesValue base = new MutableTimeSeriesValue(t0, group_name, values);
-        TimeSeriesValue a = new MutableTimeSeriesValue(t0, group_name, EMPTY_MAP);
-        TimeSeriesValue b = new MutableTimeSeriesValue(t0, GroupName.valueOf("abracadabra"), values);
-        TimeSeriesValue c = new MutableTimeSeriesValue(t0.minus(Duration.standardSeconds(1)), group_name, values);
+        TimeSeriesValue base = new MutableTimeSeriesValue(group_name, values);
+        TimeSeriesValue a = new MutableTimeSeriesValue(group_name, EMPTY_MAP);
+        TimeSeriesValue b = new MutableTimeSeriesValue(GroupName.valueOf("abracadabra"), values);
 
         assertFalse(base.equals(a));
         assertFalse(base.equals(b));
-        assertFalse(base.equals(c));
     }
 
     @Test
     public void map_is_not_shared() {
         Map<MetricName, MetricValue> local = new HashMap<>(values);
-        TimeSeriesValue tsv = new MutableTimeSeriesValue(t0, group_name, local);
+        TimeSeriesValue tsv = new MutableTimeSeriesValue(group_name, local);
         local.remove(metric_key);  // Modifying local may not affect the TimeSeriesValue.
 
         assertEquals(values, new HashMap<>(tsv.getMetrics()));
@@ -110,7 +105,7 @@ public class MutableTimeSeriesValueTest {
 
     @Test
     public void equals_across_types() {
-        TimeSeriesValue tsv = new MutableTimeSeriesValue(t0, group_name, values);
+        TimeSeriesValue tsv = new MutableTimeSeriesValue(group_name, values);
 
         assertFalse(tsv.equals(null));
         assertFalse(tsv.equals(new Object()));

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollectionPairInstanceTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollectionPairInstanceTest.java
@@ -56,18 +56,18 @@ import org.junit.Test;
  */
 public class TimeSeriesCollectionPairInstanceTest {
     private MutableTimeSeriesValue present_value(DateTime ts, int val) {
-        return new MutableTimeSeriesValue(ts, GroupName.valueOf("present"), singletonMap(MetricName.valueOf("value"), MetricValue.fromIntValue(val)));
+        return new MutableTimeSeriesValue(GroupName.valueOf("present"), singletonMap(MetricName.valueOf("value"), MetricValue.fromIntValue(val)));
     }
 
     private final DateTime date2 = new DateTime(2011, 1, 1, 0, 0, 0, DateTimeZone.UTC);
     private final DateTime date1 = new DateTime(2011, 1, 1, 0, 1, 0, DateTimeZone.UTC);
     private final DateTime date0 = new DateTime(2011, 1, 1, 0, 2, 0, DateTimeZone.UTC);
     private final MutableTimeSeriesValue pv2 = present_value(date2, 2);
-    private final MutableTimeSeriesValue date2_data = new MutableTimeSeriesValue(date2, GroupName.valueOf("date2"), EMPTY_MAP);
+    private final MutableTimeSeriesValue date2_data = new MutableTimeSeriesValue(GroupName.valueOf("date2"), EMPTY_MAP);
     private final MutableTimeSeriesValue pv1 = present_value(date1, 1);
-    private final MutableTimeSeriesValue date1_data = new MutableTimeSeriesValue(date1, GroupName.valueOf("date1"), EMPTY_MAP);
+    private final MutableTimeSeriesValue date1_data = new MutableTimeSeriesValue(GroupName.valueOf("date1"), EMPTY_MAP);
     private final MutableTimeSeriesValue pv0 = present_value(date0, 0);
-    private final MutableTimeSeriesValue date0_data = new MutableTimeSeriesValue(date0, GroupName.valueOf("date0"), EMPTY_MAP);
+    private final MutableTimeSeriesValue date0_data = new MutableTimeSeriesValue(GroupName.valueOf("date0"), EMPTY_MAP);
     private final MutableTimeSeriesCollection collection2 = new MutableTimeSeriesCollection(date2,
             Stream.concat(Stream.of(date2_data), Stream.of(pv2.clone())));
     private final MutableTimeSeriesCollection collection1 = new MutableTimeSeriesCollection(date1,

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/MetricSelectorTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/expression/MetricSelectorTest.java
@@ -68,15 +68,18 @@ public class MetricSelectorTest {
     @Before
     public void setup() {
         final MutableTimeSeriesCollection previous = new MutableTimeSeriesCollection(t0.minus(Duration.standardMinutes(1)));
-        final MutableTimeSeriesCollection current = new MutableTimeSeriesCollection(t0, Stream.of(new MutableTimeSeriesValue(t0, GroupName.valueOf("99", "Luftballons"), singletonMap(MetricName.valueOf("value"), MetricValue.fromIntValue(17)))));
-        final TimeSeriesCollectionPair ts_data = new TimeSeriesCollectionPairInstance(t0.minus(Duration.standardMinutes(2))) {{
-            startNewCycle(previous.getTimestamp(), ExpressionLookBack.EMPTY);
-            previous.getData().values().forEach(this.getCurrentCollection()::add);
-            startNewCycle(current.getTimestamp(), ExpressionLookBack.EMPTY);
-            current.getData().values().forEach(this.getCurrentCollection()::add);
-        }};
+        final MutableTimeSeriesCollection current = new MutableTimeSeriesCollection(t0, Stream.of(new MutableTimeSeriesValue(GroupName.valueOf("99", "Luftballons"), singletonMap(MetricName.valueOf("value"), MetricValue.fromIntValue(17)))));
+        final TimeSeriesCollectionPair ts_data = new TimeSeriesCollectionPairInstance(t0.minus(Duration.standardMinutes(2))) {
+            {
+                startNewCycle(previous.getTimestamp(), ExpressionLookBack.EMPTY);
+                previous.getData().values().forEach(this.getCurrentCollection()::add);
+                startNewCycle(current.getTimestamp(), ExpressionLookBack.EMPTY);
+                current.getData().values().forEach(this.getCurrentCollection()::add);
+            }
+        };
 
-        ctx = new SimpleContext(ts_data, (alert) -> {});
+        ctx = new SimpleContext(ts_data, (alert) -> {
+        });
     }
 
     @Test

--- a/impl/src/test/java/com/groupon/lex/metrics/transformers/IdentifierNameResolverTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/transformers/IdentifierNameResolverTest.java
@@ -31,10 +31,11 @@ public class IdentifierNameResolverTest {
     public void setup() {
         final GroupName group_name = GroupName.valueOf(group_path);
         final TimeSeriesCollectionPairInstance ts_data = new TimeSeriesCollectionPairInstance(DateTime.now(DateTimeZone.UTC));
-        tsv0 = new MutableTimeSeriesValue(ts_data.getCurrentCollection().getTimestamp(), group_name, EMPTY_MAP);
+        tsv0 = new MutableTimeSeriesValue(group_name, EMPTY_MAP);
         ts_data.getCurrentCollection().add(tsv0);
 
-        final MutableContext<?> m_ctx = new MutableContext<>(ts_data, (alert) -> {});
+        final MutableContext<?> m_ctx = new MutableContext<>(ts_data, (alert) -> {
+        });
         m_ctx.putGroupAlias(IDENTIFIER, group_path);
 
         ctx = m_ctx;

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/AbstractTimeSeriesValue.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/AbstractTimeSeriesValue.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 
 /**
  * Provides hashCode, equality functions.
+ *
  * @author ariane
  */
 public abstract class AbstractTimeSeriesValue implements TimeSeriesValue {
@@ -57,7 +58,7 @@ public abstract class AbstractTimeSeriesValue implements TimeSeriesValue {
 
     @Override
     public String toString() {
-        return "TimeSeriesValue{" + "timestamp=" + getTimestamp() + ", group=" + getGroup() + ", metrics=" + getMetrics() + '}';
+        return "TimeSeriesValue{" + "group=" + getGroup() + ", metrics=" + getMetrics() + '}';
     }
 
     @Override
@@ -70,9 +71,6 @@ public abstract class AbstractTimeSeriesValue implements TimeSeriesValue {
     }
 
     public static boolean equals(TimeSeriesValue a, TimeSeriesValue b) {
-        if (!Objects.equals(a.getTimestamp(), b.getTimestamp())) {
-            return false;
-        }
         if (!Objects.equals(a.getGroup(), b.getGroup())) {
             return false;
         }

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesValue.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesValue.java
@@ -38,14 +38,12 @@ import com.groupon.lex.metrics.Tagged;
 import com.groupon.lex.metrics.Tags;
 import java.util.Map;
 import java.util.Optional;
-import org.joda.time.DateTime;
 
 /**
  *
  * @author ariane
  */
 public interface TimeSeriesValue extends Cloneable, Tagged, Comparable<TimeSeriesValue> {
-    public DateTime getTimestamp();
     public GroupName getGroup();
 
     @Override
@@ -54,6 +52,7 @@ public interface TimeSeriesValue extends Cloneable, Tagged, Comparable<TimeSerie
     }
 
     public Map<MetricName, MetricValue> getMetrics();
+
     public default Optional<MetricValue> findMetric(MetricName name) {
         return Optional.ofNullable(getMetrics().get(name));
     }

--- a/processors/wavefront/src/main/java/com/groupon/lex/metrics/processors/wavefront/WavefrontPushProcessor.java
+++ b/processors/wavefront/src/main/java/com/groupon/lex/metrics/processors/wavefront/WavefrontPushProcessor.java
@@ -75,7 +75,7 @@ public class WavefrontPushProcessor implements PushProcessor {
 
             try (OutputStreamWriter out = new OutputStreamWriter(socket.getOutputStream(), CHARSET)) {
                 final Iterator<String> wavefrontStrings = tsdata.getTSValues().stream()
-                        .flatMap(WavefrontStrings::wavefrontLine)
+                        .flatMap(tsv -> WavefrontStrings.wavefrontLine(tsdata.getTimestamp(), tsv))
                         .iterator();
                 while (wavefrontStrings.hasNext()) {
                     final String line = wavefrontStrings.next();

--- a/processors/wavefront/src/main/java/com/groupon/lex/metrics/processors/wavefront/WavefrontStrings.java
+++ b/processors/wavefront/src/main/java/com/groupon/lex/metrics/processors/wavefront/WavefrontStrings.java
@@ -49,13 +49,14 @@ public class WavefrontStrings {
     public final static int MAX_TAG_KEY_VAL_CHARS = 254;  // Max of 255 chars, but need to exclude the '=' sign between tag name and tag value.
     public final static int TRUNCATE_TAG_NAME = 127;  // We truncate tag names to 128 chars, so we don't have to truncate values so much.
 
-    private WavefrontStrings() {}
+    private WavefrontStrings() {
+    }
 
     /**
      * Convert a name to a name that wavefront will accept.
      *
-     * Wavefront documentation specifies a metric consists of the characters [-a-zA-Z_0-9.]
-     * Any disallowed characters are replaced with underscores.
+     * Wavefront documentation specifies a metric consists of the characters
+     * [-a-zA-Z_0-9.] Any disallowed characters are replaced with underscores.
      */
     public static final String name(String name) {
         return name
@@ -66,15 +67,15 @@ public class WavefrontStrings {
     /**
      * Convert a group+metric to a wavefront name.
      *
-     * Concatenates the paths of a Group and a Metric, separating each path element with a dot ('.').
+     * Concatenates the paths of a Group and a Metric, separating each path
+     * element with a dot ('.').
      *
-     * Example:
-     * - group path: [ 'example', 'group', 'path' ]
-     * - and metric: [ 'metric', 'name' ]
-     * are concatenated into "example.group.path.metric.name".
+     * Example: - group path: [ 'example', 'group', 'path' ] - and metric: [
+     * 'metric', 'name' ] are concatenated into
+     * "example.group.path.metric.name".
      *
-     * The concatenated name is cleaned to only contain characters allowed by wavefront.
-     * (See the WavefrontString.name(String) function.)
+     * The concatenated name is cleaned to only contain characters allowed by
+     * wavefront. (See the WavefrontString.name(String) function.)
      */
     public static final String name(SimpleGroupPath group, MetricName metric) {
         return name(Stream.concat(group.getPath().stream(), metric.getPath().stream())
@@ -84,7 +85,8 @@ public class WavefrontStrings {
     /**
      * Does the escaping of tag values.
      *
-     * This function assumes you'll put double quotes ('"') around your tag value.
+     * This function assumes you'll put double quotes ('"') around your tag
+     * value.
      */
     private static String escapeTagValue(String tag_value) {
         return tag_value.replace("\"", "\\\"");
@@ -102,12 +104,13 @@ public class WavefrontStrings {
     }
 
     /**
-     * Truncate tag keys and values, to prevent them from exceeding the max length of a tag entry.
+     * Truncate tag keys and values, to prevent them from exceeding the max
+     * length of a tag entry.
      */
     private static Map.Entry<String, String> maybeTruncateTagEntry(Map.Entry<String, String> tag_entry) {
         String k = tag_entry.getKey();
         String v = tag_entry.getValue();
-        if (k.length() + v.length() <= MAX_TAG_KEY_VAL_CHARS - 2)  // 2 chars for the quotes around the value
+        if (k.length() + v.length() <= MAX_TAG_KEY_VAL_CHARS - 2) // 2 chars for the quotes around the value
             return tag_entry;
 
         if (k.length() > TRUNCATE_TAG_NAME)
@@ -134,7 +137,8 @@ public class WavefrontStrings {
     /**
      * Create a wavefront compatible string representation of the metric value.
      *
-     * If the metric value is empty or not representable in wavefront, an empty optional will be returned.
+     * If the metric value is empty or not representable in wavefront, an empty
+     * optional will be returned.
      */
     public static Optional<String> wavefrontValue(MetricValue mv) {
         // Omit NaN and Inf.
@@ -142,7 +146,10 @@ public class WavefrontStrings {
         return mv.value().map(Number::toString);
     }
 
-    /** Convert a timestamp to the string representation that wavefront will accept. */
+    /**
+     * Convert a timestamp to the string representation that wavefront will
+     * accept.
+     */
     public static String timestamp(DateTime ts) {
         return Long.toString(ts.getMillis() / 1000);
     }
@@ -150,8 +157,9 @@ public class WavefrontStrings {
     /**
      * Extract the 'source' tag from the tag_map.
      *
-     * Wavefront requires the 'source' tag to be the first tag on the line, hence
-     * the special handling.  It also *must* be present, so we can never return null.
+     * Wavefront requires the 'source' tag to be the first tag on the line,
+     * hence the special handling. It also *must* be present, so we can never
+     * return null.
      */
     private static String extractTagSource(Map<String, String> tag_map) {
         return Optional.ofNullable(tag_map.remove("source"))
@@ -162,7 +170,9 @@ public class WavefrontStrings {
                 });
     }
 
-    /** Build the wavefront line from its parts. */
+    /**
+     * Build the wavefront line from its parts.
+     */
     private static String wavefrontLine(DateTime ts, SimpleGroupPath group, MetricName metric, String value, String source, Map<String, String> tag_map) {
         return new StringBuilder()
                 .append(name(group, metric))
@@ -207,8 +217,7 @@ public class WavefrontStrings {
      *
      * Note: the line is not terminated with a newline.
      */
-    public static Stream<String> wavefrontLine(TimeSeriesValue tsv) {
-        final DateTime ts = tsv.getTimestamp();
+    public static Stream<String> wavefrontLine(DateTime ts, TimeSeriesValue tsv) {
         final GroupName group = tsv.getGroup();
 
         return tsv.getMetrics().entrySet().stream()

--- a/remote_history/src/main/java/com/groupon/monsoon/remote/history/EncDec.java
+++ b/remote_history/src/main/java/com/groupon/monsoon/remote/history/EncDec.java
@@ -102,7 +102,9 @@ public class EncDec {
 
     public static interface IterSuccessResponse<T> {
         public List<T> getData();
+
         public boolean isLast();
+
         public long getCookie();
     }
 
@@ -227,7 +229,6 @@ public class EncDec {
 
     private static TimeSeriesValue decodeTSV(ActiveDict dict, DateTime ts, tsfile_record tsv) {
         return new ImmutableTimeSeriesValue(
-                ts,
                 GroupName.valueOf(dict.getGroup(tsv.group_ref), dict.getTags(tsv.tag_ref)),
                 Arrays.stream(tsv.metrics),
                 m -> dict.getMetricName(m.metric_ref),

--- a/remote_history/src/main/java/com/groupon/monsoon/remote/history/ImmutableTimeSeriesValue.java
+++ b/remote_history/src/main/java/com/groupon/monsoon/remote/history/ImmutableTimeSeriesValue.java
@@ -47,20 +47,17 @@ import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
-import org.joda.time.DateTime;
 
 @Getter
 @AllArgsConstructor
 public final class ImmutableTimeSeriesValue extends AbstractTimeSeriesValue implements TimeSeriesValue {
     @NonNull
-    private final DateTime timestamp;
-    @NonNull
     private final GroupName group;
     @NonNull
     private final Map<MetricName, MetricValue> metrics;
 
-    public <T> ImmutableTimeSeriesValue(DateTime ts, GroupName group, Stream<T> metrics, Function<? super T, MetricName> name_fn, Function<? super T, MetricValue> value_fn) {
-        this(ts, group, unmodifiableMap(metrics.collect(Collectors.toMap(name_fn, value_fn, throwing_merger_(), hashmap_constructor_()))));
+    public <T> ImmutableTimeSeriesValue(GroupName group, Stream<T> metrics, Function<? super T, MetricName> name_fn, Function<? super T, MetricValue> value_fn) {
+        this(group, unmodifiableMap(metrics.collect(Collectors.toMap(name_fn, value_fn, throwing_merger_(), hashmap_constructor_()))));
     }
 
     @Override
@@ -69,10 +66,15 @@ public final class ImmutableTimeSeriesValue extends AbstractTimeSeriesValue impl
     }
 
     private static <T> BinaryOperator<T> throwing_merger_() {
-        return (x, y) -> { throw new IllegalStateException("duplicate key " + x); };
+        return (x, y) -> {
+            throw new IllegalStateException("duplicate key " + x);
+        };
     }
 
-    /** HashMap constructor, so we can create hashmaps with an altered load factor. */
+    /**
+     * HashMap constructor, so we can create hashmaps with an altered load
+     * factor.
+     */
     private static <K, V> Supplier<Map<K, V>> hashmap_constructor_() {
         return () -> new THashMap<K, V>();
     }

--- a/remote_history/src/test/java/com/groupon/monsoon/remote/history/ClientServerTest.java
+++ b/remote_history/src/test/java/com/groupon/monsoon/remote/history/ClientServerTest.java
@@ -70,17 +70,17 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.junit.After;
+import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import org.mockito.runners.MockitoJUnitRunner;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClientServerTest {
@@ -107,7 +107,7 @@ public class ClientServerTest {
                 transport = new OncRpcUdpServerTransport(server, Inet4Address.getLoopbackAddress(), 0, server.info, 32768);
                 transport.setCharacterEncoding("UTF-8");
                 portFuture.complete(transport.getPort());
-                server.run(new OncRpcServerTransport[] { transport });
+                server.run(new OncRpcServerTransport[]{transport});
             } catch (IOException | OncRpcException ex) {
                 LOG.log(Level.SEVERE, "server " + server + " failed to start", ex);
                 portFuture.completeExceptionally(ex);
@@ -425,7 +425,9 @@ public class ClientServerTest {
             private int i;
 
             @Override
-            public Integer get() { return i++; }
+            public Integer get() {
+                return i++;
+            }
         }
 
         return Stream.generate(new Generator());
@@ -440,7 +442,7 @@ public class ClientServerTest {
                 .map(i -> {
                     final DateTime t = T0.plus(Duration.standardSeconds(10 * i));
                     final MetricValue counter = MetricValue.fromIntValue(i);
-                    return new SimpleTimeSeriesCollection(t, Stream.of(new ImmutableTimeSeriesValue(t, groupName, singletonMap(metricName, counter))));
+                    return new SimpleTimeSeriesCollection(t, Stream.of(new ImmutableTimeSeriesValue(groupName, singletonMap(metricName, counter))));
                 });
     }
 
@@ -461,7 +463,7 @@ public class ClientServerTest {
         @Override
         public boolean matches(Object item) {
             if (!(item instanceof TimeSeriesMetricExpression)) return false;
-            TimeSeriesMetricExpression itemExpr = (TimeSeriesMetricExpression)item;
+            TimeSeriesMetricExpression itemExpr = (TimeSeriesMetricExpression) item;
             LOG.log(Level.FINE, "comparing {0} with {1}", new Object[]{expr.configString(), itemExpr.configString()});
             return Objects.equals(expr.configString().toString(), itemExpr.configString().toString());
         }


### PR DESCRIPTION
It wasn't used but took up a pointer everywhere.
Since there are potentially a lot of time series values, this may actually remove a couple of MB.