### PR TITLE
Fix stack overflow for reading large list files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Change log
 monsoon-2.3-SNAPSHOT
 ----
 
+Bug fixes:
+- Fix stack overflow during list file decoding.
+
 monsoon-2.2.1 (Nov 3, 2016)
 ----
 


### PR DESCRIPTION
The original code for decoding a library created a chain of
``SegmentReader.combine()`` calls. For large list files, decoding
the built chain could trigger a stack overflow error.

Instead of building a chain of ``combine()`` calls, move the loop
inside a (custom) ``SegmentReader``, eliminating the stack based
recursion.