### PR TITLE
Predicate based access to TimeSeriesCollection

### DIFF
--- a/expr/src/main/java/com/groupon/lex/metrics/MetricMatcher.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/MetricMatcher.java
@@ -35,6 +35,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.groupon.lex.metrics.lib.SimpleMapEntry;
+import com.groupon.lex.metrics.timeseries.TimeSeriesValue;
 import com.groupon.lex.metrics.timeseries.expression.Context;
 import java.util.Collection;
 import java.util.HashSet;
@@ -59,8 +60,12 @@ public class MetricMatcher {
 
     @Value
     public static final class MatchedName {
-        private final GroupName group;
+        private final TimeSeriesValue matchedGroup;
         private final MetricName metric;
+
+        public GroupName getGroup() {
+            return matchedGroup.getGroup();
+        }
 
         public Tags getTags() {
             return getGroup().getTags();
@@ -92,7 +97,7 @@ public class MetricMatcher {
                     return metric_match_cache_.getUnchecked(new HashSet<>(tsv.getMetrics().keySet())).stream()
                             .map(metric_name -> {
                                 return SimpleMapEntry.create(
-                                        new MatchedName(tsv.getGroup(), metric_name),
+                                        new MatchedName(tsv, metric_name),
                                         tsv.findMetric(metric_name).orElseThrow(() -> new IllegalStateException("resolved metric name was not present")));
                             });
                 });

--- a/expr/src/main/java/com/groupon/lex/metrics/MetricMatcher.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/MetricMatcher.java
@@ -35,7 +35,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.groupon.lex.metrics.lib.SimpleMapEntry;
-import com.groupon.lex.metrics.timeseries.TimeSeriesValueSet;
 import com.groupon.lex.metrics.timeseries.expression.Context;
 import java.util.Collection;
 import java.util.HashSet;
@@ -88,9 +87,7 @@ public class MetricMatcher {
      * Create a stream of TimeSeriesMetricDeltas with values.
      */
     public Stream<Entry<MatchedName, MetricValue>> filter(Context t) {
-        return t.getTSData().getCurrentCollection().getGroupPaths(this::match).stream()
-                .map((SimpleGroupPath group) -> t.getTSData().getTSValue(group))
-                .flatMap(TimeSeriesValueSet::stream)
+        return t.getTSData().getCurrentCollection().get(this::match, x -> true).stream()
                 .flatMap(tsv -> {
                     return metric_match_cache_.getUnchecked(new HashSet<>(tsv.getMetrics().keySet())).stream()
                             .map(metric_name -> {

--- a/expr/src/main/java/com/groupon/lex/metrics/timeseries/InterpolatedTSC.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/timeseries/InterpolatedTSC.java
@@ -44,7 +44,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -129,12 +128,9 @@ public class InterpolatedTSC extends AbstractTimeSeriesCollection implements Tim
     }
 
     @Override
-    public Set<SimpleGroupPath> getGroupPaths() {
-        Set<SimpleGroupPath> paths = new HashSet<>(current.getGroupPaths());
-        interpolatedTsvMap.keySet().stream()
-                .map(GroupName::getPath)
-                .forEach(paths::add);
-        return paths;
+    public Set<SimpleGroupPath> getGroupPaths(Predicate<? super SimpleGroupPath> filter) {
+        return Stream.concat(current.getGroupPaths(filter).stream(), interpolatedTsvMap.keySet().stream().map(GroupName::getPath).filter(filter))
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/expr/src/main/java/com/groupon/lex/metrics/timeseries/InterpolatedTSC.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/timeseries/InterpolatedTSC.java
@@ -156,6 +156,14 @@ public class InterpolatedTSC extends AbstractTimeSeriesCollection implements Tim
         return current.get(name);
     }
 
+    @Override
+    public TimeSeriesValueSet get(Predicate<? super SimpleGroupPath> pathFilter, Predicate<? super GroupName> groupFilter) {
+        return new TimeSeriesValueSet(interpolatedTsvMap.entrySet().stream()
+                .filter(entry -> pathFilter.test(entry.getKey().getPath()))
+                .filter(entry -> groupFilter.test(entry.getKey()))
+                .map(Map.Entry::getValue));
+    }
+
     /**
      * Calculate all names that can be interpolated. The returned set will not
      * have any names present in the current collection.

--- a/expr/src/test/java/com/groupon/lex/metrics/timeseries/InterpolatedTSCTest.java
+++ b/expr/src/test/java/com/groupon/lex/metrics/timeseries/InterpolatedTSCTest.java
@@ -154,7 +154,7 @@ public class InterpolatedTSCTest {
         TimeSeriesCollection present = new SimpleTimeSeriesCollection(midDate, singletonList(new ImmutableTimeSeriesValue(GroupName.valueOf("mid", "point"), emptyMap())));
         InterpolatedTSC interpolatedTSC = new InterpolatedTSC(present, singletonList(past), singletonList(future));
 
-        assertThat(interpolatedTSC.getGroups(),
+        assertThat(interpolatedTSC.getGroups(x -> true),
                 containsInAnyOrder(TESTGROUP, GroupName.valueOf("mid", "point")));
         assertThat(interpolatedTSC.getGroupPaths(),
                 containsInAnyOrder(TESTGROUP.getPath(), SimpleGroupPath.valueOf("mid", "point")));
@@ -165,7 +165,7 @@ public class InterpolatedTSCTest {
         TimeSeriesCollection present = new SimpleTimeSeriesCollection(midDate, singletonList(presentValue));
         InterpolatedTSC interpolatedTSC = new InterpolatedTSC(present, singletonList(past), singletonList(future));
 
-        assertThat(interpolatedTSC.getGroups(),
+        assertThat(interpolatedTSC.getGroups(x -> true),
                 contains(TESTGROUP));
         assertThat(interpolatedTSC.getGroupPaths(),
                 contains(TESTGROUP.getPath()));

--- a/expr/src/test/java/com/groupon/lex/metrics/timeseries/InterpolatedTSCTest.java
+++ b/expr/src/test/java/com/groupon/lex/metrics/timeseries/InterpolatedTSCTest.java
@@ -156,7 +156,7 @@ public class InterpolatedTSCTest {
 
         assertThat(interpolatedTSC.getGroups(x -> true),
                 containsInAnyOrder(TESTGROUP, GroupName.valueOf("mid", "point")));
-        assertThat(interpolatedTSC.getGroupPaths(),
+        assertThat(interpolatedTSC.getGroupPaths(x -> true),
                 containsInAnyOrder(TESTGROUP.getPath(), SimpleGroupPath.valueOf("mid", "point")));
     }
 
@@ -167,7 +167,7 @@ public class InterpolatedTSCTest {
 
         assertThat(interpolatedTSC.getGroups(x -> true),
                 contains(TESTGROUP));
-        assertThat(interpolatedTSC.getGroupPaths(),
+        assertThat(interpolatedTSC.getGroupPaths(x -> true),
                 contains(TESTGROUP.getPath()));
         assertSame(presentValue, interpolatedTSC.get(TESTGROUP).get());
     }

--- a/history/src/main/java/com/groupon/lex/metrics/history/v0/xdr/ToXdr.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v0/xdr/ToXdr.java
@@ -19,7 +19,8 @@ import org.joda.time.DateTimeZone;
  * @author ariane
  */
 public class ToXdr {
-    private ToXdr() {}
+    private ToXdr() {
+    }
 
     public static path groupname(SimpleGroupPath p) {
         path result = new path();
@@ -121,7 +122,7 @@ public class ToXdr {
     public static tsfile_datapoint datapoints(TimeSeriesCollection tsdata) {
         tsfile_datapoint result = new tsfile_datapoint();
         result.ts = timestamp(tsdata.getTimestamp());
-        result.groups = tsdata.getGroupPaths().stream()
+        result.groups = tsdata.getGroupPaths(x -> true).stream()
                 .map(path -> datapoint(path, tsdata.getTSValue(path).stream()))
                 .toArray(tsfile_pathgroup[]::new);
         return result;

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/list/ListTSC.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/list/ListTSC.java
@@ -141,6 +141,14 @@ public class ListTSC extends AbstractTimeSeriesCollection {
         return Optional.ofNullable(decode(data).get(name));
     }
 
+    @Override
+    public TimeSeriesValueSet get(Predicate<? super SimpleGroupPath> pathFilter, Predicate<? super GroupName> groupFilter) {
+        return new TimeSeriesValueSet(decode(data).entrySet().stream()
+                .filter(entry -> pathFilter.test(entry.getKey().getPath()))
+                .filter(entry -> groupFilter.test(entry.getKey()))
+                .map(Map.Entry::getValue));
+    }
+
     @RequiredArgsConstructor
     private static class RecordArray {
         private final DateTime ts;

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/list/ListTSC.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/list/ListTSC.java
@@ -116,9 +116,10 @@ public class ListTSC extends AbstractTimeSeriesCollection {
     }
 
     @Override
-    public Set<SimpleGroupPath> getGroupPaths() {
+    public Set<SimpleGroupPath> getGroupPaths(Predicate<? super SimpleGroupPath> filter) {
         return decode(data).keySet().stream()
                 .map(GroupName::getPath)
+                .filter(filter)
                 .collect(Collectors.toSet());
     }
 

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/list/ListTSC.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/list/ListTSC.java
@@ -54,12 +54,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import static java.util.Collections.unmodifiableMap;
-import static java.util.Collections.unmodifiableSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BinaryOperator;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -109,8 +109,10 @@ public class ListTSC extends AbstractTimeSeriesCollection {
     }
 
     @Override
-    public Set<GroupName> getGroups() {
-        return unmodifiableSet(decode(data).keySet());
+    public Set<GroupName> getGroups(Predicate<? super GroupName> filter) {
+        return decode(data).keySet().stream()
+                .filter(filter)
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/list/ReadWriteState.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/list/ReadWriteState.java
@@ -369,7 +369,7 @@ public final class ReadWriteState implements State {
 
     private static EncodedTscHeaderForWrite writeTSC(Writer writer, TimeSeriesCollection tsc, DictionaryForWrite dict) throws IOException, OncRpcException {
         final List<record> recordList = new ArrayList<>();
-        for (SimpleGroupPath path : tsc.getGroupPaths()) {
+        for (SimpleGroupPath path : tsc.getGroupPaths(x -> true)) {
             record r = new record();
             r.path_ref = dict.getPathTable().getOrCreate(path.getPath());
             r.tags = writeTSCTags(writer, path, tsc, dict);
@@ -383,7 +383,8 @@ public final class ReadWriteState implements State {
 
     private static record_tags[] writeTSCTags(Writer writer, SimpleGroupPath path, TimeSeriesCollection tsc, DictionaryForWrite dict) throws IOException, OncRpcException {
         final List<record_tags> recordList = new ArrayList<>();
-        for (TimeSeriesValue tsv : tsc.getTSValue(path).stream().collect(Collectors.toList())) {
+        for (TimeSeriesValue tsv
+             : tsc.getTSValue(path).stream().collect(Collectors.toList())) {
             record_tags rt = new record_tags();
             rt.tag_ref = dict.getTagsTable().getOrCreate(tsv.getTags());
             rt.pos = ToXdr.filePos(writeMetrics(writer, tsv.getMetrics(), dict));

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesCollection.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesCollection.java
@@ -117,4 +117,15 @@ public class RTFTimeSeriesCollection extends AbstractTimeSeriesCollection {
                 .filter(grpTbl -> grpTbl.contains(index))
                 .map(grpTbl -> newTSV(name, grpTbl));
     }
+
+    @Override
+    public TimeSeriesValueSet get(Predicate<? super SimpleGroupPath> pathFilter, Predicate<? super GroupName> groupFilter) {
+        return new TimeSeriesValueSet(table.decodeOrThrow().entrySet().stream()
+                .filter(entry -> pathFilter.test(entry.getKey()))
+                .flatMap(entry -> entry.getValue().entrySet().stream())
+                .filter(entry -> groupFilter.test(entry.getKey()))
+                .map(grpSegmentEntry -> SimpleMapEntry.create(grpSegmentEntry.getKey(), grpSegmentEntry.getValue().decodeOrThrow()))
+                .filter(grpTblEntry -> grpTblEntry.getValue().contains(index))
+                .map(grpTblEntry -> newTSV(grpTblEntry.getKey(), grpTblEntry.getValue())));
+    }
 }

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesCollection.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesCollection.java
@@ -76,8 +76,9 @@ public class RTFTimeSeriesCollection extends AbstractTimeSeriesCollection {
     }
 
     @Override
-    public Set<SimpleGroupPath> getGroupPaths() {
+    public Set<SimpleGroupPath> getGroupPaths(Predicate<? super SimpleGroupPath> filter) {
         return table.decodeOrThrow().entrySet().stream()
+                .filter(pathMap -> filter.test(pathMap.getKey()))
                 .filter(pathMap -> {
                     Map<GroupName, SegmentReader<RTFGroupTable>> grpMap = pathMap.getValue();
                     return grpMap.values().stream()

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesCollection.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesCollection.java
@@ -43,6 +43,7 @@ import static java.util.Collections.emptyMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.joda.time.DateTime;
@@ -65,9 +66,10 @@ public class RTFTimeSeriesCollection extends AbstractTimeSeriesCollection {
     }
 
     @Override
-    public Set<GroupName> getGroups() {
+    public Set<GroupName> getGroups(Predicate<? super GroupName> filter) {
         return table.decodeOrThrow().values().stream()
                 .flatMap(grpMap -> grpMap.entrySet().stream())
+                .filter(groupEntry -> filter.test(groupEntry.getKey()))
                 .filter(groupEntry -> groupEntry.getValue().decodeOrThrow().contains(index))
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toSet());

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/xdr/Util.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/xdr/Util.java
@@ -225,9 +225,9 @@ public class Util {
         }
 
         @Override
-        public Set<SimpleGroupPath> getGroupPaths() {
+        public Set<SimpleGroupPath> getGroupPaths(Predicate<? super SimpleGroupPath> filter) {
             return underlying.stream()
-                    .flatMap(tsc -> tsc.getGroupPaths().stream())
+                    .flatMap(tsc -> tsc.getGroupPaths(filter).stream())
                     .collect(Collectors.toSet());
         }
 

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/xdr/Util.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/xdr/Util.java
@@ -255,5 +255,14 @@ public class Util {
                     .map(Optional::get)
                     .findFirst();
         }
+
+        @Override
+        public TimeSeriesValueSet get(Predicate<? super SimpleGroupPath> pathFilter, Predicate<? super GroupName> groupFilter) {
+            return new TimeSeriesValueSet(underlying.stream()
+                    .map(tsc -> tsc.get(pathFilter, groupFilter))
+                    .flatMap(tsvSet -> tsvSet.stream())
+                    .collect(Collectors.toMap(TimeSeriesValue::getGroup, Function.identity(), (x, y) -> x)) // Conflict resolution: use first occurance.
+                    .values());
+        }
     }
 }

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/xdr/Util.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/xdr/Util.java
@@ -52,6 +52,7 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import org.joda.time.DateTime;
@@ -217,9 +218,9 @@ public class Util {
         }
 
         @Override
-        public Set<GroupName> getGroups() {
+        public Set<GroupName> getGroups(Predicate<? super GroupName> filter) {
             return underlying.stream()
-                    .flatMap(tsc -> tsc.getGroups().stream())
+                    .flatMap(tsc -> tsc.getGroups(filter).stream())
                     .collect(Collectors.toSet());
         }
 

--- a/impl/src/main/java/com/groupon/lex/metrics/config/impl/MatchTransformerImpl.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/config/impl/MatchTransformerImpl.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -34,10 +34,8 @@ package com.groupon.lex.metrics.config.impl;
 import com.groupon.lex.metrics.MetricMatcher;
 import com.groupon.lex.metrics.MetricValue;
 import com.groupon.lex.metrics.PathMatcher;
-import com.groupon.lex.metrics.SimpleGroupPath;
 import com.groupon.lex.metrics.config.MatchStatement;
 import com.groupon.lex.metrics.config.MatchStatement.IdentifierPair;
-import com.groupon.lex.metrics.lib.MemoidOne;
 import com.groupon.lex.metrics.lib.SimpleMapEntry;
 import com.groupon.lex.metrics.timeseries.ExpressionLookBack;
 import com.groupon.lex.metrics.timeseries.TimeSeriesTransformer;
@@ -48,14 +46,12 @@ import com.groupon.lex.metrics.timeseries.expression.MutableContext;
 import java.util.Collection;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -72,9 +68,9 @@ public class MatchTransformerImpl implements TimeSeriesTransformer {
     private final Collection<TimeSeriesTransformer> rules_;
 
     public MatchTransformerImpl(Map<String, PathMatcher> groupNameMatchers,
-            Map<IdentifierPair, MetricMatcher> metricNameMatchers,
-            Optional<MatchStatement.LookBackExposingPredicate> where_clause,
-            Stream<TimeSeriesTransformer> rules) {
+                                Map<IdentifierPair, MetricMatcher> metricNameMatchers,
+                                Optional<MatchStatement.LookBackExposingPredicate> where_clause,
+                                Stream<TimeSeriesTransformer> rules) {
         decorator_ = concat(group_map_(groupNameMatchers), metric_map_(metricNameMatchers));
         where_clause_ = Objects.requireNonNull(where_clause);
         rules_ = unmodifiableList(rules.collect(Collectors.toList()));
@@ -84,58 +80,45 @@ public class MatchTransformerImpl implements TimeSeriesTransformer {
         public List<Consumer<MutableContext>> map(List<Consumer<MutableContext>> in, Context ctx);
     }
 
-    /** Create a decorator map from a mapping of GroupMatchers. */
+    /**
+     * Create a decorator map from a mapping of GroupMatchers.
+     */
     private static DecoratorMap group_map_(Map<String, PathMatcher> paths) {
         if (paths.isEmpty()) return concat();
 
-        // Provide caching of group name lookups.
-        final Function<Collection<SimpleGroupPath>, List<Map.Entry<String, List<SimpleGroupPath>>>> path_mapping =
-                new MemoidOne<>((Collection<SimpleGroupPath> sgp) -> {
-                    return paths.entrySet().stream()
-                            .map(pathmatcher -> {
-                                final List<SimpleGroupPath> filtered_sgp = sgp.stream()
-                                        .filter(p -> pathmatcher.getValue().match(p.getPath()))
-                                        .collect(Collectors.toList());
-                                return SimpleMapEntry.create(pathmatcher.getKey(), filtered_sgp);
-                            })
-                            .collect(Collectors.toList());
-                });
-
         return new DecoratorMap() {
-            private List<Consumer<MutableContext>> map_(List<Consumer<MutableContext>> in, Iterator<Map.Entry<String, List<TimeSeriesValue>>> data_iter) {
-                while (data_iter.hasNext()) {
-                    final Map.Entry<String, List<TimeSeriesValue>> next = data_iter.next();
-                    final String identifier = next.getKey();
-                    LOG.log(Level.FINE, "emitting consumers for {0}", identifier);
-                    final List<Consumer<MutableContext>> reference_to_in = in;
-                    in = next.getValue().stream()
-                            .map(tsv -> {
-                                final Consumer<MutableContext> decorator = (MutableContext out) -> out.putGroupAliasByName(identifier, tsv::getGroup);
-                                return decorator;
-                            })
-                            .flatMap((Consumer<MutableContext> decorator) -> reference_to_in.stream().map(decorator::andThen))
-                            .collect(Collectors.toList());
-                }
-                return in;
-            }
-
             @Override
             public List<Consumer<MutableContext>> map(List<Consumer<MutableContext>> in, Context ctx) {
-                final Stream<Map.Entry<String, List<TimeSeriesValue>>> data = path_mapping.apply(new HashSet<>(ctx.getTSData().getCurrentCollection().getGroupPaths())).stream()
-                        .map(ident_path -> {
-                            final List<TimeSeriesValue> tsvs = ident_path.getValue().stream()
-                                    .map(ctx.getTSData().getCurrentCollection()::getTSValue)
-                                    .flatMap(TimeSeriesValueSet::stream)
-                                    .collect(Collectors.toList());
-                            return SimpleMapEntry.create(ident_path.getKey(), tsvs);
-                        });
+                final Map<String, TimeSeriesValueSet> pathMapping = paths.entrySet().stream()
+                        .collect(Collectors.toMap(Map.Entry::getKey,
+                                pmEntry -> {
+                                    return ctx.getTSData()
+                                    .getCurrentCollection()
+                                    .get(p -> pmEntry.getValue().match(p.getPath()), x -> true);
+                                }));
 
-                return map_(in, data.iterator());
+                Stream<Consumer<MutableContext>> stream = in.stream();
+                for (final Map.Entry<String, TimeSeriesValueSet> pm
+                             : pathMapping.entrySet()) {
+                    final String identifier = pm.getKey();
+                    final List<Consumer<MutableContext>> applications = pm.getValue().stream()
+                            .map(group -> {
+                                Consumer<MutableContext> application = (nestedCtx) -> nestedCtx.putGroupAliasByName(identifier, group::getGroup);
+                                return application;
+                            })
+                            .collect(Collectors.toList());
+
+                    stream = stream
+                            .flatMap(inApplication -> applications.stream().map(inApplication::andThen));
+                }
+                return stream.collect(Collectors.toList());
             }
         };
     }
 
-    /** Create a decorator map from a mapping of metric matchers. */
+    /**
+     * Create a decorator map from a mapping of metric matchers.
+     */
     private static DecoratorMap metric_map_(Map<IdentifierPair, MetricMatcher> matchers) {
         return new DecoratorMap() {
             private List<Consumer<MutableContext>> map_(Context ctx, List<Consumer<MutableContext>> in, Iterator<Map.Entry<IdentifierPair, List<Map.Entry<MetricMatcher.MatchedName, MetricValue>>>> data_iter) {
@@ -171,7 +154,9 @@ public class MatchTransformerImpl implements TimeSeriesTransformer {
         };
     }
 
-    /** Create a decorator map, by chaining zero or more decorator maps. */
+    /**
+     * Create a decorator map, by chaining zero or more decorator maps.
+     */
     private static DecoratorMap concat(DecoratorMap... d_maps) {
         return (List<Consumer<MutableContext>> in, Context ctx) -> {
             for (DecoratorMap d_map : d_maps) {
@@ -191,10 +176,12 @@ public class MatchTransformerImpl implements TimeSeriesTransformer {
     @Override
     public void transform(Context ctx) {
         decorator_
-                .map(singletonList((MutableContext mctx) -> {}), ctx)
+                .map(singletonList((MutableContext mctx) -> {
+                }), ctx)
                 .forEach(decorator -> play_rules_(decorator, ctx));
     }
 
+    @Override
     public ExpressionLookBack getLookBack() {
         return ExpressionLookBack.EMPTY.andThen(Stream.concat(
                 where_clause_.map(c -> c.getLookBack()).map(Stream::of).orElseGet(Stream::empty),

--- a/impl/src/main/java/com/groupon/lex/metrics/misc/MonitorMonitor.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/misc/MonitorMonitor.java
@@ -55,8 +55,10 @@ import org.joda.time.Duration;
 /**
  * Provides an alert for wether the monitor is running.
  *
- * The alert never fires, but is intended to be hooked up to an external alert manager,
- * which can alert if the alert hasn't been marked as OK sufficiently recently.
+ * The alert never fires, but is intended to be hooked up to an external alert
+ * manager, which can alert if the alert hasn't been marked as OK sufficiently
+ * recently.
+ *
  * @author ariane
  */
 public class MonitorMonitor implements TimeSeriesTransformer {
@@ -88,6 +90,7 @@ public class MonitorMonitor implements TimeSeriesTransformer {
 
     /**
      * Get metrics for the monitor.
+     *
      * @return All metrics for the monitor.
      */
     private Map<MetricName, MetricValue> get_metrics_(DateTime now, Context ctx) {
@@ -112,7 +115,7 @@ public class MonitorMonitor implements TimeSeriesTransformer {
 
         Map<MetricName, MetricValue> result = new HashMap<>();
         result.put(FAILED_COLLECTIONS_METRIC, MetricValue.fromIntValue(failed_collections));
-        result.put(GROUP_COUNT_METRIC, MetricValue.fromIntValue(ctx.getTSData().getCurrentCollection().getGroups().size()));
+        result.put(GROUP_COUNT_METRIC, MetricValue.fromIntValue(ctx.getTSData().getCurrentCollection().getGroups(x -> true).size()));
         result.put(METRIC_COUNT_METRIC, MetricValue.fromIntValue(metric_count));
         result.put(CONFIG_PRESENT_METRIC, MetricValue.fromBoolean(has_config));
         result.put(SCRAPE_DURATION, opt_duration_to_metricvalue_(scrape_duration));
@@ -127,6 +130,7 @@ public class MonitorMonitor implements TimeSeriesTransformer {
 
     /**
      * Emit an alert monitor.down, which is in the OK state.
+     *
      * @param ctx Rule evaluation context.
      */
     @Override
@@ -143,6 +147,7 @@ public class MonitorMonitor implements TimeSeriesTransformer {
      *
      * The returned metric value is expressed as the duration in milliseconds.
      * If the Optional is empty, an empty metric value is emitted.
+     *
      * @param duration The duration to express.
      * @return A metric value representing the duration.
      */
@@ -156,6 +161,7 @@ public class MonitorMonitor implements TimeSeriesTransformer {
      * Convert a duration to a metric value.
      *
      * The returned metric value is expressed as the duration in milliseconds.
+     *
      * @param duration The duration to express.
      * @return A metric value representing the duration.
      */

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/ChainingTSCPair.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/ChainingTSCPair.java
@@ -316,8 +316,9 @@ public abstract class ChainingTSCPair implements TimeSeriesCollectionPair {
         }
 
         @Override
-        public Set<SimpleGroupPath> getGroupPaths() {
+        public Set<SimpleGroupPath> getGroupPaths(Predicate<? super SimpleGroupPath> filter) {
             return tsvSet.entrySet().stream()
+                    .filter(entry -> filter.test(entry.getKey().getPath()))
                     .collect(Collectors.groupingBy(entry -> entry.getKey().getPath())).entrySet().stream()
                     .filter(listing -> listing.getValue().stream().map(Map.Entry::getValue).anyMatch(Optional::isPresent))
                     .map(Map.Entry::getKey)

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/ChainingTSCPair.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/ChainingTSCPair.java
@@ -347,6 +347,16 @@ public abstract class ChainingTSCPair implements TimeSeriesCollectionPair {
             return tsvSet.getOrDefault(name, Optional.empty());
         }
 
+        @Override
+        public TimeSeriesValueSet get(Predicate<? super SimpleGroupPath> pathFilter, Predicate<? super GroupName> groupFilter) {
+            return new TimeSeriesValueSet(tsvSet.entrySet().stream()
+                    .filter(entry -> pathFilter.test(entry.getKey().getPath()))
+                    .filter(entry -> groupFilter.test(entry.getKey()))
+                    .map(Map.Entry::getValue)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get));
+        }
+
         private Optional<TimeSeriesValue> faultGroup(GroupName name) {
             final TsvChain tsvChain = data.get(name);
             if (tsvChain == null)

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollection.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollection.java
@@ -186,6 +186,15 @@ public class MutableTimeSeriesCollection extends AbstractTimeSeriesCollection im
         return Optional.ofNullable(data_.get(name));
     }
 
+    @Override
+    public TimeSeriesValueSet get(Predicate<? super SimpleGroupPath> pathFilter, Predicate<? super GroupName> groupFilter) {
+        return new TimeSeriesValueSet(data_by_path_.entrySet().stream()
+                .filter(entry -> pathFilter.test(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .flatMap(Collection::stream)
+                .filter(tsv -> groupFilter.test(tsv.getGroup())));
+    }
+
     public Map<GroupName, TimeSeriesValue> getData() {
         return unmodifiableMap(data_);
     }

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollection.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollection.java
@@ -46,8 +46,10 @@ import java.util.Map;
 import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -154,8 +156,10 @@ public class MutableTimeSeriesCollection extends AbstractTimeSeriesCollection im
     }
 
     @Override
-    public Set<GroupName> getGroups() {
-        return unmodifiableSet(new HashSet<>(data_.keySet()));  // Copy of the keyset, since Map.keySet is a view.
+    public Set<GroupName> getGroups(Predicate<? super GroupName> predicate) {
+        return data_.keySet().stream()
+                .filter(predicate)
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollection.java
+++ b/impl/src/main/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollection.java
@@ -39,7 +39,6 @@ import java.util.Collection;
 import static java.util.Collections.singletonMap;
 import static java.util.Collections.unmodifiableCollection;
 import static java.util.Collections.unmodifiableMap;
-import static java.util.Collections.unmodifiableSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -163,8 +162,10 @@ public class MutableTimeSeriesCollection extends AbstractTimeSeriesCollection im
     }
 
     @Override
-    public Set<SimpleGroupPath> getGroupPaths() {
-        return unmodifiableSet(new HashSet<>(data_by_path_.keySet()));
+    public Set<SimpleGroupPath> getGroupPaths(Predicate<? super SimpleGroupPath> filter) {
+        return data_by_path_.keySet().stream()
+                .filter(filter)
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/impl/src/test/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollectionTest.java
+++ b/impl/src/test/java/com/groupon/lex/metrics/timeseries/MutableTimeSeriesCollectionTest.java
@@ -69,7 +69,7 @@ public class MutableTimeSeriesCollectionTest {
 
         assertEquals(t0, ts_data.getTimestamp());
         assertTrue(ts_data.getTSValues().isEmpty());
-        assertTrue(ts_data.getGroups().isEmpty());
+        assertTrue(ts_data.getGroups(x -> true).isEmpty());
         assertTrue(ts_data.isEmpty());
     }
 
@@ -81,7 +81,7 @@ public class MutableTimeSeriesCollectionTest {
         assertThat(ts_data.getTSValues().stream()
                 .collect(Collectors.toList()),
                 hasItem(ts_value));
-        assertThat(ts_data.getGroups(),
+        assertThat(ts_data.getGroups(x -> true),
                 hasItem(GroupName.valueOf(group_name, EMPTY_MAP)));
         assertFalse(ts_data.isEmpty());
     }
@@ -162,7 +162,7 @@ public class MutableTimeSeriesCollectionTest {
         assertThat(ts_data.getTSValues().stream()
                 .collect(Collectors.toList()),
                 hasItem(EXPECT_TS_AFTER_RENAME));
-        assertThat(ts_data.getGroups(),
+        assertThat(ts_data.getGroups(x -> true),
                 hasItem(GroupName.valueOf("post", "rename")));
         assertFalse(ts_data.isEmpty());
     }

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/EmptyTimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/EmptyTimeSeriesCollection.java
@@ -37,12 +37,14 @@ import java.util.Collection;
 import static java.util.Collections.EMPTY_SET;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.joda.time.DateTime;
 
 /**
  * An empty time series collection.
+ *
  * @author ariane
  */
 @RequiredArgsConstructor
@@ -56,7 +58,7 @@ public class EmptyTimeSeriesCollection extends AbstractTimeSeriesCollection {
     }
 
     @Override
-    public Set<GroupName> getGroups() {
+    public Set<GroupName> getGroups(Predicate<? super GroupName> filter) {
         return EMPTY_SET;
     }
 

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/EmptyTimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/EmptyTimeSeriesCollection.java
@@ -63,7 +63,7 @@ public class EmptyTimeSeriesCollection extends AbstractTimeSeriesCollection {
     }
 
     @Override
-    public Set<SimpleGroupPath> getGroupPaths() {
+    public Set<SimpleGroupPath> getGroupPaths(Predicate<? super SimpleGroupPath> filter) {
         return EMPTY_SET;
     }
 

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/EmptyTimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/EmptyTimeSeriesCollection.java
@@ -81,4 +81,9 @@ public class EmptyTimeSeriesCollection extends AbstractTimeSeriesCollection {
     public Optional<TimeSeriesValue> get(GroupName name) {
         return Optional.empty();
     }
+
+    @Override
+    public TimeSeriesValueSet get(Predicate<? super SimpleGroupPath> pathFilter, Predicate<? super GroupName> groupFilter) {
+        return TimeSeriesValueSet.EMPTY;
+    }
 }

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/SimpleTimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/SimpleTimeSeriesCollection.java
@@ -36,7 +36,6 @@ import com.groupon.lex.metrics.SimpleGroupPath;
 import gnu.trove.map.hash.THashMap;
 import java.util.Collection;
 import static java.util.Collections.unmodifiableCollection;
-import static java.util.Collections.unmodifiableSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -118,8 +117,10 @@ public class SimpleTimeSeriesCollection extends AbstractTimeSeriesCollection {
     }
 
     @Override
-    public Set<SimpleGroupPath> getGroupPaths() {
-        return unmodifiableSet(pathMap.keySet());
+    public Set<SimpleGroupPath> getGroupPaths(Predicate<? super SimpleGroupPath> filter) {
+        return pathMap.keySet().stream()
+                .filter(filter)
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/SimpleTimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/SimpleTimeSeriesCollection.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BinaryOperator;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,8 +51,9 @@ import lombok.NonNull;
 import org.joda.time.DateTime;
 
 /**
- * A simple time series collection.
- * This implementation uses trove hashmap to minimize memory usage.
+ * A simple time series collection. This implementation uses trove hashmap to
+ * minimize memory usage.
+ *
  * @author ariane
  */
 public class SimpleTimeSeriesCollection extends AbstractTimeSeriesCollection {
@@ -61,19 +63,27 @@ public class SimpleTimeSeriesCollection extends AbstractTimeSeriesCollection {
     private final Map<SimpleGroupPath, List<TimeSeriesValue>> pathMap;
 
     private static BinaryOperator<TimeSeriesValue> throwing_merger_() {
-        return (x, y) -> { throw new IllegalArgumentException("duplicate group " + x.getGroup()); };
+        return (x, y) -> {
+            throw new IllegalArgumentException("duplicate group " + x.getGroup());
+        };
     }
 
-    /** HashMap constructor, so we can create hashmaps with an altered load factor. */
+    /**
+     * HashMap constructor, so we can create hashmaps with an altered load
+     * factor.
+     */
     private static <K, V> Supplier<Map<K, V>> hashmap_constructor_() {
         return () -> new THashMap<>(1, 1);
     }
 
     /**
      * Construct a time series collection.
+     *
      * @param timestamp The timestamp of the collection.
-     * @param tsv A stream of values for the collection.  The values stream may not have duplicate group names.
-     * @throws IllegalArgumentException if the time series values contain duplicate group names.
+     * @param tsv A stream of values for the collection. The values stream may
+     * not have duplicate group names.
+     * @throws IllegalArgumentException if the time series values contain
+     * duplicate group names.
      */
     public SimpleTimeSeriesCollection(@NonNull DateTime timestamp, @NonNull Stream<? extends TimeSeriesValue> tsv) {
         this.timestamp = timestamp;
@@ -84,9 +94,12 @@ public class SimpleTimeSeriesCollection extends AbstractTimeSeriesCollection {
 
     /**
      * Construct a time series collection.
+     *
      * @param timestamp The timestamp of the collection.
-     * @param tsv A collection of values for the collection.  The values stream may not have duplicate group names.
-     * @throws IllegalArgumentException if the time series values contain duplicate group names.
+     * @param tsv A collection of values for the collection. The values stream
+     * may not have duplicate group names.
+     * @throws IllegalArgumentException if the time series values contain
+     * duplicate group names.
      */
     public SimpleTimeSeriesCollection(@NonNull DateTime timestamp, @NonNull Collection<? extends TimeSeriesValue> tsv) {
         this(timestamp, tsv.stream());
@@ -98,8 +111,10 @@ public class SimpleTimeSeriesCollection extends AbstractTimeSeriesCollection {
     }
 
     @Override
-    public Set<GroupName> getGroups() {
-        return unmodifiableSet(groupMap.keySet());
+    public Set<GroupName> getGroups(Predicate<? super GroupName> filter) {
+        return groupMap.keySet().stream()
+                .filter(filter)
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/SimpleTimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/SimpleTimeSeriesCollection.java
@@ -139,4 +139,12 @@ public class SimpleTimeSeriesCollection extends AbstractTimeSeriesCollection {
     public Optional<TimeSeriesValue> get(GroupName name) {
         return Optional.ofNullable(groupMap.get(name));
     }
+
+    @Override
+    public TimeSeriesValueSet get(Predicate<? super SimpleGroupPath> pathFilter, Predicate<? super GroupName> groupFilter) {
+        return new TimeSeriesValueSet(groupMap.entrySet().stream()
+                .filter(entry -> pathFilter.test(entry.getKey().getPath()))
+                .filter(entry -> groupFilter.test(entry.getKey()))
+                .map(Map.Entry::getValue));
+    }
 }

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollection.java
@@ -56,13 +56,20 @@ public interface TimeSeriesCollection extends Comparable<TimeSeriesCollection> {
 
     public Set<GroupName> getGroups(Predicate<? super GroupName> filter);
 
-    public Set<SimpleGroupPath> getGroupPaths();
+    public Set<SimpleGroupPath> getGroupPaths(Predicate<? super SimpleGroupPath> filter);
 
     public Collection<TimeSeriesValue> getTSValues();
 
     public TimeSeriesValueSet getTSValue(SimpleGroupPath name);
 
     public Optional<TimeSeriesValue> get(GroupName name);
+
+    public default TimeSeriesValueSet get(Predicate<? super SimpleGroupPath> pathFilter, Predicate<? super GroupName> groupFilter) {
+        return new TimeSeriesValueSet(getGroups(name -> pathFilter.test(name.getPath()) && groupFilter.test(name)).stream()
+                .map(this::get)
+                .filter(Optional::isPresent)
+                .map(Optional::get));
+    }
 
     public default Optional<TimeSeriesValueSet> getTSDeltaByName(GroupName name) {
         return get(name)

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollection.java
@@ -36,6 +36,7 @@ import com.groupon.lex.metrics.SimpleGroupPath;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -50,11 +51,17 @@ public interface TimeSeriesCollection extends Comparable<TimeSeriesCollection> {
     }
 
     public DateTime getTimestamp();
+
     public boolean isEmpty();
-    public Set<GroupName> getGroups();
+
+    public Set<GroupName> getGroups(Predicate<? super GroupName> filter);
+
     public Set<SimpleGroupPath> getGroupPaths();
+
     public Collection<TimeSeriesValue> getTSValues();
+
     public TimeSeriesValueSet getTSValue(SimpleGroupPath name);
+
     public Optional<TimeSeriesValue> get(GroupName name);
 
     public default Optional<TimeSeriesValueSet> getTSDeltaByName(GroupName name) {

--- a/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollection.java
+++ b/intf/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesCollection.java
@@ -64,12 +64,7 @@ public interface TimeSeriesCollection extends Comparable<TimeSeriesCollection> {
 
     public Optional<TimeSeriesValue> get(GroupName name);
 
-    public default TimeSeriesValueSet get(Predicate<? super SimpleGroupPath> pathFilter, Predicate<? super GroupName> groupFilter) {
-        return new TimeSeriesValueSet(getGroups(name -> pathFilter.test(name.getPath()) && groupFilter.test(name)).stream()
-                .map(this::get)
-                .filter(Optional::isPresent)
-                .map(Optional::get));
-    }
+    public TimeSeriesValueSet get(Predicate<? super SimpleGroupPath> pathFilter, Predicate<? super GroupName> groupFilter);
 
     public default Optional<TimeSeriesValueSet> getTSDeltaByName(GroupName name) {
         return get(name)


### PR DESCRIPTION
Allows dynamic TimeSeriesCollection instances to fault in only the paths/groups that are requested, by applying a filter prior to faulting in.