### PR TITLE
Path matcher parsing

### DIFF
--- a/expr/src/main/antlr4/com/groupon/lex/metrics/timeseries/parser/PathMatcherGrammar.g4
+++ b/expr/src/main/antlr4/com/groupon/lex/metrics/timeseries/parser/PathMatcherGrammar.g4
@@ -1,0 +1,15 @@
+parser grammar PathMatcherGrammar;
+options {
+    tokenVocab=PathMatcherLexer;
+}
+import ExprBnf;
+
+@header {
+    import com.groupon.lex.metrics.PathMatcher;
+}
+
+
+expr             returns [ PathMatcher s ]
+                 : s1=path_match EOF
+                   { $s = $s1.s; }
+                 ;

--- a/expr/src/main/antlr4/com/groupon/lex/metrics/timeseries/parser/PathMatcherLexer.g4
+++ b/expr/src/main/antlr4/com/groupon/lex/metrics/timeseries/parser/PathMatcherLexer.g4
@@ -1,0 +1,2 @@
+lexer grammar PathMatcherLexer;
+import MonsoonExprLexer;

--- a/expr/src/main/antlr4/imports/ExprBnf.g4
+++ b/expr/src/main/antlr4/imports/ExprBnf.g4
@@ -40,6 +40,7 @@ import MonsoonPrimitivesParser;
     import com.groupon.lex.metrics.expression.LiteralGroupExpression;
     import com.groupon.lex.metrics.lib.Any2;
     import com.groupon.lex.metrics.lib.TriFunction;
+    import com.groupon.lex.metrics.timeseries.TimeSeriesMetricExpression;
     import com.groupon.lex.metrics.timeseries.TagAggregationClause;
     import com.groupon.lex.metrics.timeseries.TagMatchingClause;
     import com.groupon.lex.metrics.timeseries.expression.AvgExpression;

--- a/expr/src/main/java/com/groupon/lex/metrics/PathMatcher.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/PathMatcher.java
@@ -141,9 +141,8 @@ public class PathMatcher {
 
         @Override
         public boolean isLiteral() {
-            return successor_
-                    .map(IdentifierMatch::isLiteral)
-                    .orElse(true);
+            if (successor_.isPresent()) return successor_.get().isLiteral();
+            return true;
         }
 
         @Override
@@ -388,7 +387,7 @@ public class PathMatcher {
     }
 
     public PathMatcher(List<IdentifierMatch> matchers) {
-        List<IdentifierMatch> reversed_matchers = new ArrayList<IdentifierMatch>(matchers);  // Create a copy, since we don't want to mangle the input argument.
+        List<IdentifierMatch> reversed_matchers = new ArrayList<>(matchers);  // Create a copy, since we don't want to mangle the input argument.
         Collections.reverse(reversed_matchers);
 
         IdentifierMatch match_head = reversed_matchers.remove(0);

--- a/expr/src/main/java/com/groupon/lex/metrics/expression/GroupExpression.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/expression/GroupExpression.java
@@ -31,6 +31,7 @@
  */
 package com.groupon.lex.metrics.expression;
 
+import com.groupon.lex.metrics.PathMatcher;
 import com.groupon.lex.metrics.timeseries.PrintableExpression;
 import com.groupon.lex.metrics.timeseries.TimeSeriesValueSet;
 import com.groupon.lex.metrics.timeseries.expression.Context;
@@ -47,4 +48,6 @@ public interface GroupExpression extends PrintableExpression {
     public default int getPriority() {
         return BRACKETS;
     }
+
+    public PathMatcher getPathMatcher();
 }

--- a/expr/src/main/java/com/groupon/lex/metrics/expression/IdentifierGroupExpression.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/expression/IdentifierGroupExpression.java
@@ -32,6 +32,7 @@
 package com.groupon.lex.metrics.expression;
 
 import com.groupon.lex.metrics.ConfigSupport;
+import com.groupon.lex.metrics.PathMatcher;
 import com.groupon.lex.metrics.timeseries.TimeSeriesValueSet;
 import com.groupon.lex.metrics.timeseries.expression.Context;
 import java.util.Objects;
@@ -51,6 +52,11 @@ public class IdentifierGroupExpression implements GroupExpression {
     public TimeSeriesValueSet getTSDelta(Context<?> ctx) {
         return ctx.getGroupFromIdentifier(identifier_)
                 .orElse(TimeSeriesValueSet.EMPTY);
+    }
+
+    @Override
+    public PathMatcher getPathMatcher() {
+        return new PathMatcher(new PathMatcher.DoubleWildcardMatch());
     }
 
     @Override

--- a/expr/src/main/java/com/groupon/lex/metrics/expression/LiteralGroupExpression.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/expression/LiteralGroupExpression.java
@@ -31,6 +31,7 @@
  */
 package com.groupon.lex.metrics.expression;
 
+import com.groupon.lex.metrics.PathMatcher;
 import com.groupon.lex.metrics.SimpleGroupPath;
 import com.groupon.lex.metrics.timeseries.TimeSeriesValueSet;
 import com.groupon.lex.metrics.timeseries.expression.Context;
@@ -50,6 +51,11 @@ public class LiteralGroupExpression implements GroupExpression {
 
     public NameResolver getName() {
         return name_;
+    }
+
+    @Override
+    public PathMatcher getPathMatcher() {
+        return name_.getPathMatcher();
     }
 
     @Override

--- a/expr/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesMetricAggregate.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesMetricAggregate.java
@@ -89,6 +89,18 @@ public abstract class TimeSeriesMetricAggregate<T> implements TimeSeriesMetricEx
         return exprs_;
     }
 
+    private TimeSeriesMetricFilter getMatchersFilter() {
+        return matchers_.stream()
+                .reduce(new TimeSeriesMetricFilter(), TimeSeriesMetricFilter::withMetric, TimeSeriesMetricFilter::with);
+    }
+
+    @Override
+    public TimeSeriesMetricFilter getNameFilter() {
+        return getChildren().stream()
+                .map(child -> child.getNameFilter())
+                .reduce(getMatchersFilter(), TimeSeriesMetricFilter::with);
+    }
+
     @Override
     public final ExpressionLookBack getLookBack() {
         final ChainableExpressionLookBack base = tDelta

--- a/expr/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesMetricExpression.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesMetricExpression.java
@@ -121,6 +121,16 @@ public interface TimeSeriesMetricExpression extends Function<Context<?>, TimeSer
     }
 
     /**
+     * @return A filter that describes all groups and metrics that are required
+     * to properly evaluate the expression.
+     */
+    public default TimeSeriesMetricFilter getNameFilter() {
+        return getChildren().stream()
+                .map(child -> child.getNameFilter())
+                .reduce(new TimeSeriesMetricFilter(), TimeSeriesMetricFilter::with);
+    }
+
+    /**
      * Read expression from string.
      *
      * @param str A string containing an expression.

--- a/expr/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesMetricFilter.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/timeseries/TimeSeriesMetricFilter.java
@@ -1,0 +1,96 @@
+package com.groupon.lex.metrics.timeseries;
+
+import com.groupon.lex.metrics.MetricMatcher;
+import com.groupon.lex.metrics.PathMatcher;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Represents a group of metrics that are required for an expression to function.
+ */
+@Getter
+@EqualsAndHashCode
+@ToString
+public class TimeSeriesMetricFilter {
+    private final Set<PathMatcher> groups;
+    private final Set<MetricMatcher> metrics;
+
+    public TimeSeriesMetricFilter() {
+        this.groups = emptySet();
+        this.metrics = emptySet();
+    }
+
+    private TimeSeriesMetricFilter(TimeSeriesMetricFilter orig, PathMatcher group) {
+        this.metrics = orig.getMetrics();
+
+        if (orig.getGroups().isEmpty()) {
+            this.groups = singleton(group);
+        } else {
+            final HashSet<PathMatcher> newGroups = new HashSet<>(orig.getGroups());
+            if (newGroups.add(group)) {
+                this.groups = newGroups;
+            } else {
+                this.groups = orig.getGroups();
+            }
+        }
+    }
+
+    private TimeSeriesMetricFilter(TimeSeriesMetricFilter orig, MetricMatcher metric) {
+        this.groups = orig.getGroups();
+
+        if (orig.getMetrics().isEmpty()) {
+            this.metrics = singleton(metric);
+        } else {
+            final HashSet<MetricMatcher> newMetrics = new HashSet<>(orig.getMetrics());
+            if (newMetrics.add(metric)) {
+                this.metrics = newMetrics;
+            } else {
+                this.metrics = orig.getMetrics();
+            }
+        }
+    }
+
+    public TimeSeriesMetricFilter withGroup(PathMatcher group) {
+        return new TimeSeriesMetricFilter(this, group);
+    }
+
+    public TimeSeriesMetricFilter withMetric(MetricMatcher metric) {
+        return new TimeSeriesMetricFilter(this, metric);
+    }
+
+    public TimeSeriesMetricFilter withGroups(Iterator<PathMatcher> groups) {
+        TimeSeriesMetricFilter result = this;
+        while (groups.hasNext())
+            result = result.withGroup(groups.next());
+        return result;
+    }
+
+    public TimeSeriesMetricFilter withGroups(Iterable<PathMatcher> groups) {
+        return withGroups(groups.iterator());
+    }
+
+    public TimeSeriesMetricFilter withMetrics(Iterator<MetricMatcher> metrics) {
+        TimeSeriesMetricFilter result = this;
+        while (metrics.hasNext())
+            result = result.withMetric(metrics.next());
+        return result;
+    }
+
+    public TimeSeriesMetricFilter withMetrics(Iterable<MetricMatcher> metrics) {
+        return withMetrics(metrics.iterator());
+    }
+
+    public TimeSeriesMetricFilter with(TimeSeriesMetricFilter other) {
+        return withGroups(other.getGroups()).withMetrics(other.getMetrics());
+    }
+
+    public boolean isEmpty() {
+        return getMetrics().isEmpty() && getGroups().isEmpty();
+    }
+}

--- a/expr/src/main/java/com/groupon/lex/metrics/timeseries/expression/IdentifierMetricSelector.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/timeseries/expression/IdentifierMetricSelector.java
@@ -3,6 +3,7 @@ package com.groupon.lex.metrics.timeseries.expression;
 import com.groupon.lex.metrics.ConfigSupport;
 import com.groupon.lex.metrics.timeseries.TimeSeriesMetricDeltaSet;
 import com.groupon.lex.metrics.timeseries.TimeSeriesMetricExpression;
+import com.groupon.lex.metrics.timeseries.TimeSeriesMetricFilter;
 import static com.groupon.lex.metrics.timeseries.expression.Priorities.BRACKETS;
 import java.util.Collection;
 import java.util.Collections;
@@ -20,6 +21,11 @@ public class IdentifierMetricSelector implements TimeSeriesMetricExpression {
 
     @Override
     public Collection<TimeSeriesMetricExpression> getChildren() { return Collections.EMPTY_LIST; }
+
+    @Override
+    public TimeSeriesMetricFilter getNameFilter() {
+        return new TimeSeriesMetricFilter();
+    }
 
     @Override
     public TimeSeriesMetricDeltaSet apply(Context<?> ctx) {

--- a/expr/src/main/java/com/groupon/lex/metrics/timeseries/expression/MetricSelector.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/timeseries/expression/MetricSelector.java
@@ -31,10 +31,12 @@
  */
 package com.groupon.lex.metrics.timeseries.expression;
 
+import com.groupon.lex.metrics.MetricMatcher;
 import com.groupon.lex.metrics.MetricName;
 import com.groupon.lex.metrics.expression.GroupExpression;
 import com.groupon.lex.metrics.timeseries.TimeSeriesMetricDeltaSet;
 import com.groupon.lex.metrics.timeseries.TimeSeriesMetricExpression;
+import com.groupon.lex.metrics.timeseries.TimeSeriesMetricFilter;
 import static com.groupon.lex.metrics.timeseries.expression.Priorities.BRACKETS;
 import com.groupon.lex.metrics.transformers.LiteralNameResolver;
 import com.groupon.lex.metrics.transformers.NameResolver;
@@ -62,6 +64,12 @@ public class MetricSelector implements TimeSeriesMetricExpression {
     public NameResolver getMetric() { return metric_; }
     @Override
     public Collection<TimeSeriesMetricExpression> getChildren() { return Collections.EMPTY_LIST; }
+
+    @Override
+    public TimeSeriesMetricFilter getNameFilter() {
+        return new TimeSeriesMetricFilter()
+                .withMetric(new MetricMatcher(group_.getPathMatcher(), metric_.getPathMatcher()));
+    }
 
     @Override
     public TimeSeriesMetricDeltaSet apply(Context ctx) {

--- a/expr/src/main/java/com/groupon/lex/metrics/timeseries/expression/NameExpression.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/timeseries/expression/NameExpression.java
@@ -35,6 +35,7 @@ import com.groupon.lex.metrics.MetricValue;
 import com.groupon.lex.metrics.Path;
 import com.groupon.lex.metrics.timeseries.TimeSeriesMetricDeltaSet;
 import com.groupon.lex.metrics.timeseries.TimeSeriesMetricExpression;
+import com.groupon.lex.metrics.timeseries.TimeSeriesMetricFilter;
 import static com.groupon.lex.metrics.timeseries.expression.Priorities.BRACKETS;
 import com.groupon.lex.metrics.transformers.NameResolver;
 import java.util.Collection;
@@ -95,6 +96,16 @@ public class NameExpression implements TimeSeriesMetricExpression {
     @Override
     public Collection<TimeSeriesMetricExpression> getChildren() {
         return EMPTY_LIST;
+    }
+
+    @Override
+    public TimeSeriesMetricFilter getNameFilter() {
+        /*
+         * Return an empty filter:
+         * - in the case identifiers are referenced, the identifier match will populate the filter.
+         * - in the case of a literal name, the group/metric is not required to do the transformation.
+         */
+        return new TimeSeriesMetricFilter();
     }
 
     @Override

--- a/expr/src/main/java/com/groupon/lex/metrics/timeseries/expression/TimeSeriesMetricSelector.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/timeseries/expression/TimeSeriesMetricSelector.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -31,13 +31,17 @@
  */
 package com.groupon.lex.metrics.timeseries.expression;
 
+import com.groupon.lex.metrics.MetricMatcher;
 import com.groupon.lex.metrics.MetricName;
+import com.groupon.lex.metrics.PathMatcher;
 import com.groupon.lex.metrics.expression.GroupExpression;
 import com.groupon.lex.metrics.timeseries.TimeSeriesMetricDeltaSet;
 import com.groupon.lex.metrics.timeseries.TimeSeriesMetricExpression;
+import com.groupon.lex.metrics.timeseries.TimeSeriesMetricFilter;
 import static com.groupon.lex.metrics.timeseries.expression.Priorities.BRACKETS;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -54,6 +58,15 @@ public class TimeSeriesMetricSelector implements TimeSeriesMetricExpression {
 
     @Override
     public Collection<TimeSeriesMetricExpression> getChildren() { return Collections.EMPTY_LIST; }
+
+    @Override
+    public TimeSeriesMetricFilter getNameFilter() {
+        final PathMatcher metricMatcher = new PathMatcher(metric_.getPath().stream()
+                .map(PathMatcher.LiteralNameMatch::new)
+                .collect(Collectors.toList()));
+        return new TimeSeriesMetricFilter()
+                .withMetric(new MetricMatcher(group_.getPathMatcher(), metricMatcher));
+    }
 
     public GroupExpression getGroup() { return group_; }
     public MetricName getMetric() { return metric_; }

--- a/expr/src/main/java/com/groupon/lex/metrics/transformers/LiteralNameResolver.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/transformers/LiteralNameResolver.java
@@ -32,12 +32,14 @@
 package com.groupon.lex.metrics.transformers;
 
 import com.groupon.lex.metrics.Path;
+import com.groupon.lex.metrics.PathMatcher;
 import com.groupon.lex.metrics.SimpleGroupPath;
 import com.groupon.lex.metrics.timeseries.expression.Context;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -66,6 +68,13 @@ public class LiteralNameResolver implements NameResolver {
     @Override
     public StringBuilder configString() {
         return group_name_.configString();
+    }
+
+    @Override
+    public List<PathMatcher.IdentifierMatch> asLiteral() {
+        return group_name_.getPath().stream()
+                .map(PathMatcher.LiteralNameMatch::new)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/expr/src/main/java/com/groupon/lex/metrics/transformers/NameResolver.java
+++ b/expr/src/main/java/com/groupon/lex/metrics/transformers/NameResolver.java
@@ -32,8 +32,10 @@
 package com.groupon.lex.metrics.transformers;
 
 import com.groupon.lex.metrics.Path;
+import com.groupon.lex.metrics.PathMatcher;
 import com.groupon.lex.metrics.timeseries.expression.Context;
 import static com.groupon.lex.metrics.timeseries.expression.Util.pairwiseMap;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -61,6 +63,22 @@ public interface NameResolver extends Function<Context<?>, Optional<Path>> {
      * @return A string describing this statement.
      */
     public StringBuilder configString();
+
+    /**
+     * Retrieves the literal name, if possible.
+     * If the evaluation requires bound names, this function will return an empty optional.
+     * @return A list of strings representing the literal name, if possible to resolve without context.
+     */
+    public List<PathMatcher.IdentifierMatch> asLiteral();
+
+    /**
+     * Retrieves a path matcher that captures all names matched by this name resolver.
+     * The path matcher may capture more names than needed.
+     * @return A PathMatcher which indicates a match for everything matched by this name resolver.
+     */
+    public default PathMatcher getPathMatcher() {
+        return new PathMatcher(asLiteral());
+    }
 
     /**
      * Combine two group name resolvers into a single group name resolver.
@@ -102,6 +120,14 @@ public interface NameResolver extends Function<Context<?>, Optional<Path>> {
             return a_.configString()
                     .append('.')
                     .append(b_.configString());
+        }
+
+        @Override
+        public List<PathMatcher.IdentifierMatch> asLiteral() {
+            List<PathMatcher.IdentifierMatch> identifiers = new ArrayList<>();
+            identifiers.addAll(a_.asLiteral());
+            identifiers.addAll(b_.asLiteral());
+            return identifiers;
         }
 
         @Override

--- a/expr/src/test/java/com/groupon/lex/metrics/expression/GroupExpressionTest.java
+++ b/expr/src/test/java/com/groupon/lex/metrics/expression/GroupExpressionTest.java
@@ -1,21 +1,21 @@
 /*
  * Copyright (c) 2016, Groupon, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met: 
+ * are met:
  *
  * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer. 
+ * this list of conditions and the following disclaimer.
  *
  * Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution. 
+ * documentation and/or other materials provided with the distribution.
  *
  * Neither the name of GROUPON nor the names of its contributors may be
  * used to endorse or promote products derived from this software without
- * specific prior written permission. 
+ * specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -31,6 +31,7 @@
  */
 package com.groupon.lex.metrics.expression;
 
+import com.groupon.lex.metrics.PathMatcher;
 import com.groupon.lex.metrics.timeseries.TimeSeriesValueSet;
 import com.groupon.lex.metrics.timeseries.expression.Context;
 import static com.groupon.lex.metrics.timeseries.expression.Priorities.BRACKETS;
@@ -50,6 +51,11 @@ public class GroupExpressionTest {
 
         @Override
         public StringBuilder configString() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public PathMatcher getPathMatcher() {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
     }

--- a/expr/src/test/java/com/groupon/lex/metrics/timeseries/ExprNameFilterTest.java
+++ b/expr/src/test/java/com/groupon/lex/metrics/timeseries/ExprNameFilterTest.java
@@ -1,0 +1,41 @@
+package com.groupon.lex.metrics.timeseries;
+
+import com.groupon.lex.metrics.MetricMatcher;
+import com.groupon.lex.metrics.PathMatcher;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class ExprNameFilterTest {
+    @Test
+    public void noNamesUsed() throws Exception {
+        assertEquals(new TimeSeriesMetricFilter(), TimeSeriesMetricExpression.valueOf("true").getNameFilter());
+        assertEquals(new TimeSeriesMetricFilter(), TimeSeriesMetricExpression.valueOf("false").getNameFilter());
+        assertEquals(new TimeSeriesMetricFilter(), TimeSeriesMetricExpression.valueOf("1.0 / 2").getNameFilter());
+        assertEquals(new TimeSeriesMetricFilter(), TimeSeriesMetricExpression.valueOf("\"foo\"").getNameFilter());
+    }
+
+    @Test
+    public void nameMatch() throws Exception {
+        assertEquals(
+                new TimeSeriesMetricFilter()
+                        .withMetric(new MetricMatcher(
+                                new PathMatcher(new PathMatcher.LiteralNameMatch("foo")),
+                                new PathMatcher(new PathMatcher.LiteralNameMatch("bar")))),
+                TimeSeriesMetricExpression.valueOf("sum(foo bar)").getNameFilter()
+        );
+    }
+
+    @Test
+    public void twoNameMatch() throws Exception {
+        assertEquals(
+                new TimeSeriesMetricFilter()
+                        .withMetric(new MetricMatcher(
+                                new PathMatcher(new PathMatcher.LiteralNameMatch("foo")),
+                                new PathMatcher(new PathMatcher.LiteralNameMatch("bar"))))
+                        .withMetric(new MetricMatcher(
+                                new PathMatcher(new PathMatcher.LiteralNameMatch("foobarium")),
+                                new PathMatcher(new PathMatcher.LiteralNameMatch("barium")))),
+                TimeSeriesMetricExpression.valueOf("foo bar * foobarium barium").getNameFilter()
+        );
+    }
+}


### PR DESCRIPTION
Allows expressions to generate sets of paths that are needed for the expression to be resolved.