### PR TITLE
Remove iterator/stream wrappers from BufferedIterator.

### DIFF
--- a/exporter/src/main/java/com/groupon/lex/metrics/Exporter.java
+++ b/exporter/src/main/java/com/groupon/lex/metrics/Exporter.java
@@ -5,22 +5,21 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.stream.JsonWriter;
 import com.groupon.lex.metrics.history.xdr.DirCollectHistory;
 import com.groupon.lex.metrics.json.Json;
-import com.groupon.lex.metrics.lib.BufferedIterator;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import lombok.Getter;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.ParserProperties;
-import java.nio.file.Path;
-import java.util.Iterator;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 class Exporter {
     private static final Logger LOG = Logger.getLogger(Exporter.class.getName());
@@ -83,7 +82,7 @@ class Exporter {
 
         out.beginArray();
         try {
-            final Iterator<TimeSeriesCollection> tsdata_iter = BufferedIterator.stream(src.stream()).iterator();
+            final Iterator<TimeSeriesCollection> tsdata_iter = src.stream().iterator();
             while (tsdata_iter.hasNext()) {
                 final TimeSeriesCollection tsdata = tsdata_iter.next();
                 Json.toJson(gson, out, tsdata);

--- a/history/src/test/java/com/groupon/lex/metrics/history/xdr/DirCollectHistoryTest.java
+++ b/history/src/test/java/com/groupon/lex/metrics/history/xdr/DirCollectHistoryTest.java
@@ -8,7 +8,6 @@ package com.groupon.lex.metrics.history.xdr;
 import static com.groupon.lex.metrics.history.xdr.TSDataFileChainTest.CHAIN_WIDTH;
 import com.groupon.lex.metrics.history.xdr.support.FileSupport;
 import com.groupon.lex.metrics.history.xdr.support.StreamedCollection;
-import com.groupon.lex.metrics.lib.BufferedIterator;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -64,7 +63,7 @@ public class DirCollectHistoryTest {
     @Test
     public void size_stays_below_threshold() throws Exception {
         LOG.log(Level.INFO, "starting test");
-        final Iterator<TimeSeriesCollection> iter = BufferedIterator.iterator(create_tsdata_().iterator());
+        final Iterator<TimeSeriesCollection> iter = create_tsdata_().iterator();
         // First, grow until 90%, to get an estimate of file size usage.
         int count_until_90_percent = 0;
         while (getTmpdirSize() < 9 * LIMIT / 10) {

--- a/impl-intf/src/main/java/com/groupon/lex/metrics/history/CollectHistory.java
+++ b/impl-intf/src/main/java/com/groupon/lex/metrics/history/CollectHistory.java
@@ -3,7 +3,6 @@ package com.groupon.lex.metrics.history;
 import com.groupon.lex.metrics.GroupName;
 import static com.groupon.lex.metrics.history.HistoryContext.LOOK_BACK;
 import static com.groupon.lex.metrics.history.HistoryContext.LOOK_FORWARD;
-import com.groupon.lex.metrics.lib.BufferedIterator;
 import com.groupon.lex.metrics.lib.SimpleMapEntry;
 import com.groupon.lex.metrics.timeseries.ExpressionLookBack;
 import com.groupon.lex.metrics.timeseries.TimeSeriesCollection;
@@ -115,7 +114,7 @@ public interface CollectHistory {
      * Return a History Context for evaluating expressions.
      */
     public default Stream<Context> getContext(Duration stepsize, ExpressionLookBack lookback, TimeSeriesMetricFilter filter) {
-        return HistoryContext.stream(BufferedIterator.stream(stream(stepsize)), lookback);
+        return HistoryContext.stream(stream(stepsize), lookback);
     }
 
     /**
@@ -123,7 +122,7 @@ public interface CollectHistory {
      * 'begin' timestamp (inclusive).
      */
     public default Stream<Context> getContext(DateTime begin, Duration stepsize, ExpressionLookBack lookback, TimeSeriesMetricFilter filter) {
-        return HistoryContext.stream(BufferedIterator.stream(stream(begin.minus(lookback.hintDuration()), stepsize)), lookback)
+        return HistoryContext.stream(stream(begin.minus(lookback.hintDuration()), stepsize), lookback)
                 .filter(ctx -> !ctx.getTSData().getCurrentCollection().getTimestamp().isBefore(begin));
     }
 
@@ -132,7 +131,7 @@ public interface CollectHistory {
      * timestamp (inclusive) and the 'end' timestamp (inclusive).
      */
     public default Stream<Context> getContext(DateTime begin, DateTime end, Duration stepsize, ExpressionLookBack lookback, TimeSeriesMetricFilter filter) {
-        return HistoryContext.stream(BufferedIterator.stream(stream(begin.minus(lookback.hintDuration()), end, stepsize)), lookback)
+        return HistoryContext.stream(stream(begin.minus(lookback.hintDuration()), end, stepsize), lookback)
                 .filter(ctx -> !ctx.getTSData().getCurrentCollection().getTimestamp().isBefore(begin));
     }
 

--- a/lib/src/test/java/com/groupon/lex/metrics/lib/BufferedIteratorTest.java
+++ b/lib/src/test/java/com/groupon/lex/metrics/lib/BufferedIteratorTest.java
@@ -4,11 +4,17 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -17,19 +23,19 @@ import org.junit.Test;
 public class BufferedIteratorTest {
     @Test(timeout = 8000)
     public void empty_iterator_test() {
-        Iterator<?> iterator = BufferedIterator.iterator(Stream.empty().iterator());
+        Iterator<?> iterator = blockingIterator(Stream.empty().iterator());
 
         assertFalse(iterator.hasNext());
     }
 
     @Test(expected = NoSuchElementException.class, timeout = 8000)
     public void empty_iterator_next_test() {
-        BufferedIterator.iterator(Stream.empty().iterator()).next();
+        blockingIterator(Stream.empty().iterator()).next();
     }
 
     @Test(timeout = 8000)
     public void nonempty_iterator_test() {
-        Iterator<?> iterator = BufferedIterator.iterator(Stream.of("foobar").iterator());
+        Iterator<?> iterator = blockingIterator(Stream.of("foobar").iterator());
 
         assertTrue(iterator.hasNext());
         assertEquals("foobar", iterator.next());
@@ -38,7 +44,7 @@ public class BufferedIteratorTest {
 
     @Test(timeout = 8000)
     public void iteration() {
-        List<Integer> visited = BufferedIterator.stream(Stream.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20))
+        List<Integer> visited = blockingStream(Stream.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20))
                 .collect(Collectors.toList());
 
         assertEquals(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20), visited);
@@ -46,7 +52,7 @@ public class BufferedIteratorTest {
 
     @Test(timeout = 80000)
     public void blocking_iteration() {
-        Stream<Integer> stream = BufferedIterator.stream(Stream.generate(new Supplier<Integer>() {
+        Stream<Integer> stream = blockingStream(Stream.generate(new Supplier<Integer>() {
             private int i = 0;
 
             @Override
@@ -61,5 +67,42 @@ public class BufferedIteratorTest {
         }));
 
         assertEquals(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), stream.limit(10).collect(Collectors.toList()));
+    }
+
+    private static <T> Iterator<T> blockingIterator(Iterator<T> iter) {
+        return new BlockingIterator<>(new BufferedIterator<>(iter));
+    }
+
+    private static <T> Stream<T> blockingStream(Stream<T> stream) {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(blockingIterator(stream.iterator()), Spliterator.ORDERED), false);
+    }
+
+    /**
+     * It's a bad idea to do this, as buffering of already buffered computations
+     * will lead to potential deadlock if all executor threads are committed to
+     * iteration.
+     */
+    @RequiredArgsConstructor
+    private static class BlockingIterator<T> implements Iterator<T> {
+        @NonNull
+        private final BufferedIterator<T> iter;
+
+        @Override
+        @SneakyThrows
+        public boolean hasNext() {
+            iter.waitAvail();
+            assert (iter.nextAvail() || iter.atEnd());
+            return !iter.atEnd();
+        }
+
+        @Override
+        @SneakyThrows
+        public T next() {
+            iter.waitAvail();
+            if (iter.atEnd())
+                throw new NoSuchElementException();
+            assert (iter.nextAvail());
+            return iter.next();
+        }
     }
 }


### PR DESCRIPTION
The temptation is too large to just throw them in along a stream/iteration,
to split a computation over multiple threads (or deal with IO). But the
downside is that this will lead to deadlock scenarios, where all threads are
used for BufferedIterators, which are all waiting for other BufferedIterators
to do their work. And of course the latter can't, because they're waiting for
threads...