### PR TITLE
Use faster bulk decoding logic.

### DIFF
--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesCollection.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesCollection.java
@@ -67,8 +67,8 @@ public class RTFTimeSeriesCollection extends AbstractTimeSeriesCollection {
 
     @Override
     public Set<GroupName> getGroups(Predicate<? super GroupName> filter) {
-        return table.decodeOrThrow().values().stream()
-                .flatMap(grpMap -> grpMap.entrySet().stream())
+        return table.decodeOrThrow().values().parallelStream()
+                .flatMap(grpMap -> grpMap.entrySet().parallelStream())
                 .filter(groupEntry -> filter.test(groupEntry.getKey()))
                 .filter(groupEntry -> groupEntry.getValue().decodeOrThrow().contains(index))
                 .map(Map.Entry::getKey)
@@ -77,11 +77,11 @@ public class RTFTimeSeriesCollection extends AbstractTimeSeriesCollection {
 
     @Override
     public Set<SimpleGroupPath> getGroupPaths(Predicate<? super SimpleGroupPath> filter) {
-        return table.decodeOrThrow().entrySet().stream()
+        return table.decodeOrThrow().entrySet().parallelStream()
                 .filter(pathMap -> filter.test(pathMap.getKey()))
                 .filter(pathMap -> {
                     Map<GroupName, SegmentReader<RTFGroupTable>> grpMap = pathMap.getValue();
-                    return grpMap.values().stream()
+                    return grpMap.values().parallelStream()
                             .anyMatch(grp -> grp.decodeOrThrow().contains(index));
                 })
                 .map(Map.Entry::getKey)
@@ -94,8 +94,8 @@ public class RTFTimeSeriesCollection extends AbstractTimeSeriesCollection {
 
     @Override
     public Collection<TimeSeriesValue> getTSValues() {
-        return table.decodeOrThrow().values().stream()
-                .flatMap(grpMap -> grpMap.entrySet().stream())
+        return table.decodeOrThrow().values().parallelStream()
+                .flatMap(grpMap -> grpMap.entrySet().parallelStream())
                 .map(grpEntry -> SimpleMapEntry.create(grpEntry.getKey(), grpEntry.getValue().decodeOrThrow()))
                 .filter(grpEntry -> grpEntry.getValue().contains(index))
                 .map(grpEntry -> newTSV(grpEntry.getKey(), grpEntry.getValue()))
@@ -104,7 +104,7 @@ public class RTFTimeSeriesCollection extends AbstractTimeSeriesCollection {
 
     @Override
     public TimeSeriesValueSet getTSValue(SimpleGroupPath name) {
-        return new TimeSeriesValueSet(table.decodeOrThrow().get(name).entrySet().stream()
+        return new TimeSeriesValueSet(table.decodeOrThrow().get(name).entrySet().parallelStream()
                 .map(grpEntry -> SimpleMapEntry.create(grpEntry.getKey(), grpEntry.getValue().decodeOrThrow()))
                 .filter(grpEntry -> grpEntry.getValue().contains(index))
                 .map(grpEntry -> newTSV(grpEntry.getKey(), grpEntry.getValue())));
@@ -120,9 +120,9 @@ public class RTFTimeSeriesCollection extends AbstractTimeSeriesCollection {
 
     @Override
     public TimeSeriesValueSet get(Predicate<? super SimpleGroupPath> pathFilter, Predicate<? super GroupName> groupFilter) {
-        return new TimeSeriesValueSet(table.decodeOrThrow().entrySet().stream()
+        return new TimeSeriesValueSet(table.decodeOrThrow().entrySet().parallelStream()
                 .filter(entry -> pathFilter.test(entry.getKey()))
-                .flatMap(entry -> entry.getValue().entrySet().stream())
+                .flatMap(entry -> entry.getValue().entrySet().parallelStream())
                 .filter(entry -> groupFilter.test(entry.getKey()))
                 .map(grpSegmentEntry -> SimpleMapEntry.create(grpSegmentEntry.getKey(), grpSegmentEntry.getValue().decodeOrThrow()))
                 .filter(grpTblEntry -> grpTblEntry.getValue().contains(index))

--- a/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesValue.java
+++ b/history/src/main/java/com/groupon/lex/metrics/history/v2/tables/RTFTimeSeriesValue.java
@@ -61,7 +61,7 @@ public class RTFTimeSeriesValue extends AbstractTimeSeriesValue {
 
     @Override
     public Map<MetricName, MetricValue> getMetrics() {
-        return tbl.getMetrics().entrySet().stream()
+        return tbl.getMetrics().entrySet().parallelStream()
                 .map(entry -> SimpleMapEntry.create(entry.getKey(), entry.getValue().decodeOrThrow()))
                 .filter(entry -> entry.getValue().contains(index))
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().get(index)));

--- a/impl-intf/src/main/java/com/groupon/lex/metrics/history/CollectHistory.java
+++ b/impl-intf/src/main/java/com/groupon/lex/metrics/history/CollectHistory.java
@@ -12,6 +12,7 @@ import com.groupon.lex.metrics.timeseries.TimeSeriesMetricFilter;
 import com.groupon.lex.metrics.timeseries.TimeSeriesValue;
 import com.groupon.lex.metrics.timeseries.expression.Context;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -31,6 +32,15 @@ public interface CollectHistory {
     public boolean add(TimeSeriesCollection tsv);
 
     public boolean addAll(Collection<? extends TimeSeriesCollection> c);
+
+    public default boolean addAll(Iterator<? extends TimeSeriesCollection> i) {
+        boolean changed = false;
+        while (i.hasNext()) {
+            if (add(i.next()))
+                changed = true;
+        }
+        return changed;
+    }
 
     public long getFileSize();
 

--- a/remote_history/src/test/java/com/groupon/monsoon/remote/history/ClientServerTest.java
+++ b/remote_history/src/test/java/com/groupon/monsoon/remote/history/ClientServerTest.java
@@ -164,7 +164,7 @@ public class ClientServerTest {
     public void add() throws Exception {
         // Invokes the addAll method.
         List<TimeSeriesCollection> expected = generateCollection().limit(1).collect(Collectors.toList());
-        when(history.addAll(Mockito.any())).thenReturn(true);
+        when(history.addAll(Mockito.<Collection<? extends TimeSeriesCollection>>any())).thenReturn(true);
 
         client.add(expected.get(0));
 
@@ -175,7 +175,7 @@ public class ClientServerTest {
     @Test
     public void addAll() throws Exception {
         List<TimeSeriesCollection> expected = generateCollection().collect(Collectors.toList());
-        when(history.addAll(Mockito.any())).thenReturn(true);
+        when(history.addAll(Mockito.<Collection<? extends TimeSeriesCollection>>any())).thenReturn(true);
 
         client.addAll(expected);
 


### PR DESCRIPTION
Parallelize decoding operations for faster bulk decoding.

While here, create ``CollectHistory.addAll(Iterator)`` method as alternative insertion method.