### PR TITLE
Work around telegraf limitations.

### DIFF
--- a/extra/influx-copy/src/main/java/com/github/groupon/monsoon/history/influx/FileConvert.java
+++ b/extra/influx-copy/src/main/java/com/github/groupon/monsoon/history/influx/FileConvert.java
@@ -32,6 +32,9 @@ public class FileConvert {
     @Option(name = "--database", usage = "Influx database to where data will be written")
     private String database;
 
+    @Option(name = "--skip_db_check", usage = "Don't check if the database exists (useful if you're using telegraf for instance)")
+    private boolean skipDatabaseExistCheck = false;
+
     @Argument(metaVar = "/src/dir", usage = "path: which dir contains source files", index = 0)
     private String srcdir;
 
@@ -77,7 +80,7 @@ public class FileConvert {
     public void run() throws IOException, Exception {
         final CollectHistory src = new DirCollectHistory(srcdir_path_);
         try {
-            final CollectHistory dst = new InfluxHistory(InfluxDBFactory.connect(influxDst).enableGzip(), database);
+            final CollectHistory dst = new InfluxHistory(InfluxDBFactory.connect(influxDst).enableGzip(), database, !skipDatabaseExistCheck);
             try {
                 copy(src, dst);
             } finally {


### PR DESCRIPTION
Telegraf cannot handle the database-exist test, so allow for that to be
suppressed.

Telegraf does not handle lines longer than 64k. So we work around this by
testing if a line is shorter than 32k (gives plenty of buffer).